### PR TITLE
Use phone's back camera

### DIFF
--- a/src/components/CameraUploader.tsx
+++ b/src/components/CameraUploader.tsx
@@ -37,6 +37,7 @@ const CameraUploader: FC<Props> = ({ setFiles, setView }: Props) => {
                     audio={false}
                     ref={webcamRef}
                     screenshotFormat="image/jpeg"
+                    videoConstraints={{ facingMode: 'environment' }}
                     className="max-h-[24rem] h-max rounded-xl"
                 />
 


### PR DESCRIPTION
This pull request updates the CameraUploader component to use the phone's back camera by default. This improves the user experience by providing a better quality image. The videoConstraints property has been added to the component with the value of 'environment' to achieve this.

Fixes: [#993](https://github.com/uNotesOfficial/unotes-next/issues/993)