### PR TITLE
refactor: refactor `use progress` hook

### DIFF
--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,44 +1,50 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
-import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler';
+import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler'
 
 // add interface
 interface ProgressHook {
-    progress: number;
-    handler: XhrHttpHandler;
+    progress: number
+    handler: XhrHttpHandler
 }
 
 const useProgress = (files: File[]): ProgressHook => {
     // handler can be a const because we do nt need to change it betwenn two render calls
-    const handler = new XhrHttpHandler({});
+    const handler = new XhrHttpHandler({})
 
-    const [progress, setProgress] = useState<number>(0);
+    const [progress, setProgress] = useState<number>(0)
     useEffect(() => {
         const handleUploadProgress = (xhr: ProgressEvent) => {
             if (xhr.lengthComputable) {
-                const newProgress = Math.round((xhr.loaded / xhr.total) * 100);
-                setProgress(newProgress);
+                const newProgress = Math.round((xhr.loaded / xhr.total) * 100)
+                setProgress(newProgress)
 
                 if (newProgress === 100) {
-                    handler.off(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
+                    handler.off(
+                        XhrHttpHandler.EVENTS.UPLOAD_PROGRESS,
+                        handleUploadProgress,
+                    )
                 }
             }
-        };
+        }
 
-        handler.on(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
+        handler.on(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress)
 
         // Cleanup event listener on unmount or when `files` change
         return () => {
-            handler.off(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
-            setProgress(0);
-        };
-    }, [files]);
+            handler.off(
+                XhrHttpHandler.EVENTS.UPLOAD_PROGRESS,
+                handleUploadProgress,
+            )
+            setProgress(0)
+        }
+    }, [files])
 
     return {
         progress,
         handler,
-    };
-};
+    }
+}
 
-export default useProgress;
+export default useProgress

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,47 +1,44 @@
-import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler'
-import { useCallback, useEffect, useState } from 'react'
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react';
 
-const useProgress = (files: File[]) => {
-    const [progress, setProgress] = useState(0)
-    const [handler] = useState(new XhrHttpHandler({}) as any)
+import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler';
+
+// add interface
+interface ProgressHook {
+    progress: number;
+    handler: XhrHttpHandler;
+}
+
+const useProgress = (files: File[]): ProgressHook => {
+    // handler can be a const because we do nt need to change it betwenn two render calls
+    const handler = new XhrHttpHandler({});
+
+    const [progress, setProgress] = useState<number>(0);
     useEffect(() => {
-        if (progress > 0) {
-            console.log(
-                progress === 100
-                    ? '%cUPLOAD COMPLETE'
-                    : `%cUpload Progress : ${progress}%`,
-                `color: ${progress === 100 ? '#00ff00' : '#ff9600'}`,
-            )
-        }
-        if (progress === 100) {
-            handler.off(
-                XhrHttpHandler.EVENTS.UPLOAD_PROGRESS,
-                handleUploadProgress,
-            )
-        }
-    }, [progress, files])
+        const handleUploadProgress = (xhr: ProgressEvent) => {
+            if (xhr.lengthComputable) {
+                const newProgress = Math.round((xhr.loaded / xhr.total) * 100);
+                setProgress(newProgress);
 
-    const handleUploadProgress = useCallback((xhr: ProgressEvent) => {
-        setProgress(Math.round((xhr.loaded / xhr.total) * 100))
-    }, [])
+                if (newProgress === 100) {
+                    handler.off(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
+                }
+            }
+        };
 
-    useEffect(() => {
-        handler.on(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress)
+        handler.on(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
 
-        // Cleanup function to remove the event listener when component unmounts
+        // Cleanup event listener on unmount or when `files` change
         return () => {
-            handler.off(
-                XhrHttpHandler.EVENTS.UPLOAD_PROGRESS,
-                handleUploadProgress,
-            )
-            setProgress(0)
-        }
-    }, [files])
+            handler.off(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
+            setProgress(0);
+        };
+    }, [files, handler]);
 
     return {
         progress,
         handler,
-    }
-}
+    };
+};
 
-export default useProgress
+export default useProgress;

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -33,7 +33,7 @@ const useProgress = (files: File[]): ProgressHook => {
             handler.off(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, handleUploadProgress);
             setProgress(0);
         };
-    }, [files, handler]);
+    }, [files]);
 
     return {
         progress,

--- a/src/lib/checkFileType.ts
+++ b/src/lib/checkFileType.ts
@@ -1,32 +1,30 @@
-
 /**
  * Check if the file type matche the accepted file types.
  * @param {File} file - The file to check.
- * @param {string } acceptedFiles - Accepted file types. Can be file extensions ('jpg') or MIME types ('image/jpeg') 
+ * @param {string } acceptedFiles - Accepted file types. Can be file extensions ('jpg') or MIME types ('image/jpeg')
  * @returns {boolean} - True if the file type is accepted, false otherwise.
  */
 export function checkFileType(file: File, acceptedFiles: string) {
     if (!file || !acceptedFiles || acceptedFiles === '*') {
-        return true; 
+        return true
     }
 
     const acceptedFilesArray = Array.isArray(acceptedFiles)
         ? acceptedFiles
-        : acceptedFiles.split(',');
+        : acceptedFiles.split(',')
 
-    const { name: fileName, type: mimeType } = file;
-    const extension = fileName ? fileName.split('.').pop()?.toLowerCase() : '';
+    const { name: fileName, type: mimeType } = file
+    const extension = fileName ? fileName.split('.').pop()?.toLowerCase() : ''
 
     return acceptedFilesArray.some(type => {
-        type = type.trim().toLowerCase();
+        type = type.trim().toLowerCase()
         if (type.startsWith('.')) {
             // Check by file extension
-            return type.slice(1) === extension;
+            return type.slice(1) === extension
         } else {
             // Check by MIME type
-            const baseMimeType = mimeType.split('/')[0];
-            return type === mimeType || type === `${baseMimeType}/*`;
+            const baseMimeType = mimeType.split('/')[0]
+            return type === mimeType || type === `${baseMimeType}/*`
         }
-    });
+    })
 }
-

--- a/src/lib/checkFileType.ts
+++ b/src/lib/checkFileType.ts
@@ -1,20 +1,32 @@
-export function checkFileType(file: File, acceptedFiles: string) {
-    if (file && acceptedFiles && acceptedFiles !== '*') {
-        const acceptedFilesArray = Array.isArray(acceptedFiles)
-            ? acceptedFiles
-            : acceptedFiles.split(',')
-        const { name: fileName, type: mimeType } = file
-        const baseMimeType = mimeType.replace(/\/.*$/, '')
-        const extension = mimeType.split('/')[1]
 
-        return (
-            acceptedFilesArray.includes(extension) ||
-            acceptedFilesArray.includes(mimeType) ||
-            acceptedFilesArray.includes(`${baseMimeType}/*`) ||
-            acceptedFilesArray.some(
-                type => type.startsWith('.') && fileName.endsWith(type),
-            )
-        )
+/**
+ * Check if the file type matche the accepted file types.
+ * @param {File} file - The file to check.
+ * @param {string } acceptedFiles - Accepted file types. Can be file extensions ('jpg') or MIME types ('image/jpeg') 
+ * @returns {boolean} - True if the file type is accepted, false otherwise.
+ */
+export function checkFileType(file: File, acceptedFiles: string) {
+    if (!file || !acceptedFiles || acceptedFiles === '*') {
+        return true; 
     }
-    return true
+
+    const acceptedFilesArray = Array.isArray(acceptedFiles)
+        ? acceptedFiles
+        : acceptedFiles.split(',');
+
+    const { name: fileName, type: mimeType } = file;
+    const extension = fileName ? fileName.split('.').pop()?.toLowerCase() : '';
+
+    return acceptedFilesArray.some(type => {
+        type = type.trim().toLowerCase();
+        if (type.startsWith('.')) {
+            // Check by file extension
+            return type.slice(1) === extension;
+        } else {
+            // Check by MIME type
+            const baseMimeType = mimeType.split('/')[0];
+            return type === mimeType || type === `${baseMimeType}/*`;
+        }
+    });
 }
+


### PR DESCRIPTION
make handle as const there is no need to state
add interface progresshook
verification xhr.lengthComputable valide to calclul new progress create handleUploadProgress in use effect to create it only when we needed and Encapsulated it verify new progress in the handleuploadprogress to lake it clean and to avoid extra effect Cleanup event listener on unmount or when files change