### PR TITLE
feat: replace dev command with concurrently to run storybook and server

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
         "decompress"
     ],
     "scripts": {
-        "dev": "tsup --config tsup.config.ts --watch",
+        "dev": "concurrently \"pnpm run storybook\" \"pnpm run dev:server\" --names \"storybook,server\" --prefix-colors \"blue,green\"",
+        "dev:build": "tsup --config tsup.config.ts --watch",
         "dev:server": "node ./server/index.js",
         "build:css": "postcss src/frontend/tailwind.css -o ./dist/tailwind-prefixed.css",
         "build": "pnpm run prebuild && tsup --config tsup.config.ts && pnpm run build:css",
@@ -93,7 +94,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     },
     "devDependencies": {
-        "@playwright/test": "^1.47.2",
         "@babel/core": "^7.23.3",
         "@babel/plugin-proposal-optional-chaining": "^7.21.0",
         "@babel/preset-env": "^7.23.3",
@@ -104,6 +104,7 @@
         "@emotion/is-prop-valid": "^1.3.1",
         "@eslint/compat": "^1.2.5",
         "@eslint/js": "^9.19.0",
+        "@playwright/test": "^1.47.2",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-replace": "^6.0.2",
@@ -133,6 +134,7 @@
         "@typescript-eslint/parser": "^8.22.0",
         "autoprefixer": "^10.4.20",
         "babel-loader": "^9.1.3",
+        "concurrently": "^9.2.1",
         "css-loader": "^7.1.2",
         "dotenv": "^17.2.1",
         "eslint": "^9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ devDependencies:
   babel-loader:
     specifier: ^9.1.3
     version: 9.2.1(@babel/core@7.28.3)(webpack@5.89.0)
+  concurrently:
+    specifier: ^9.2.1
+    version: 9.2.1
   css-loader:
     specifier: ^7.1.2
     version: 7.1.2(webpack@5.89.0)
@@ -6276,6 +6279,19 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+    dev: true
+
   /confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
@@ -11806,6 +11822,12 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
+  /rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+
   /safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -11965,6 +11987,11 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
+
+  /shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /side-channel-list@1.0.0:


### PR DESCRIPTION
## Description
Replace the dev command to run both the storybook and server middleware together using concurrently

## Changes Made
- ✅ Add concurrently as dev dependency
- ✅ Update dev command to run both storybook and server middleware simultaneously  
- ✅ Add dev:build command to preserve original tsup watch functionality
- ✅ Configure color-coded output (blue for storybook, green for server) for better developer experience

## Testing
- [x] Verified both storybook and server start correctly with `pnpm dev`
- [x] Confirmed color-coded output works as expected
- [x] Tested that both services run concurrently without issues

## Related Issue
Closes #289

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing functionality)

## Developer Experience
This change significantly improves the development workflow by allowing developers to start both the Storybook development server and the backend middleware with a single command, making the development setup much more convenient.