### PR TITLE
fix: fix preview bugs

### DIFF
--- a/packages/upup/src/frontend/components/AdapterSelector.tsx
+++ b/packages/upup/src/frontend/components/AdapterSelector.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react'
 import { useRootContext } from '../context/RootContext'
 import useAdapterSelector from '../hooks/useAdapterSelector'
 import { cn } from '../lib/tailwind'
-import MainBoxHeader from './shared/MainBoxHeader'
 import ShouldRender from './shared/ShouldRender'
 
 export default function AdapterSelector() {
@@ -77,14 +76,62 @@ export default function AdapterSelector() {
     return (
         <div
             className={cn(
-                'upup-relative upup-flex upup-h-full upup-flex-col-reverse upup-items-center upup-justify-center upup-gap-3 upup-rounded-lg md:upup-flex-col md:upup-gap-14',
+                'upup-relative upup-flex upup-h-full upup-items-center upup-justify-center upup-gap-3 upup-rounded-lg',
                 {
-                    'md:upup-pt-0': isAddingMore,
+                    'upup-flex-col': isAddingMore,
+                    'upup-flex-col-reverse md:upup-flex-col md:upup-gap-14':
+                        !isAddingMore,
                 },
             )}
         >
             <ShouldRender if={isAddingMore}>
-                <MainBoxHeader handleCancel={() => setIsAddingMore(false)} />
+                <div
+                    className={cn(
+                        'upup-shadow-bottom upup-flex upup-w-full upup-items-center upup-rounded-t-lg upup-bg-black/[0.025] upup-px-3 upup-py-2',
+                        {
+                            'upup-bg-white/5 dark:upup-bg-white/5': dark,
+                        },
+                        classNames.containerHeader,
+                    )}
+                >
+                    <button
+                        className={cn(
+                            'upup-flex upup-items-center upup-gap-1 upup-text-sm upup-font-medium upup-text-blue-600',
+                            {
+                                'upup-text-[#30C5F7] dark:upup-text-[#30C5F7]':
+                                    dark,
+                            },
+                            classNames.containerCancelButton,
+                        )}
+                        onClick={() => setIsAddingMore(false)}
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <polyline points="15 18 9 12 15 6" />
+                        </svg>
+                        Back
+                    </button>
+                    <span
+                        className={cn(
+                            'upup-flex-1 upup-text-center upup-text-sm upup-text-[#6D6D6D]',
+                            {
+                                'upup-text-gray-300 dark:upup-text-gray-300':
+                                    dark,
+                            },
+                        )}
+                    >
+                        Adding more files
+                    </span>
+                </div>
             </ShouldRender>
             <ShouldRender if={!mini}>
                 <div
@@ -136,8 +183,8 @@ export default function AdapterSelector() {
                 multiple={multiple}
                 onChange={handleInputFileChange}
             />
-            <div className="upup-flex upup-flex-col upup-items-center upup-gap-1 upup-text-center md:upup-gap-2 md:upup-px-[30px]">
-                <div className="upup-flex upup-items-center upup-gap-1">
+            <div className="upup-flex upup-flex-col upup-items-center upup-gap-1 upup-px-3 upup-text-center md:upup-gap-2 md:upup-px-[30px]">
+                <div className="upup-flex upup-flex-wrap upup-items-center upup-justify-center upup-gap-1">
                     <span
                         className={cn(
                             'upup-text-xs upup-text-[#0B0B0B] md:upup-text-sm',

--- a/packages/upup/src/frontend/components/AdapterSelector.tsx
+++ b/packages/upup/src/frontend/components/AdapterSelector.tsx
@@ -76,10 +76,10 @@ export default function AdapterSelector() {
     return (
         <div
             className={cn(
-                'upup-relative upup-flex upup-h-full upup-items-center upup-justify-center upup-gap-3 upup-rounded-lg',
+                'upup-relative upup-flex upup-h-full upup-gap-3 upup-rounded-lg',
                 {
                     'upup-flex-col': isAddingMore,
-                    'upup-flex-col-reverse md:upup-flex-col md:upup-gap-14':
+                    'upup-flex-col-reverse upup-items-center upup-justify-center md:upup-flex-col md:upup-gap-14':
                         !isAddingMore,
                 },
             )}

--- a/packages/upup/src/frontend/components/FileItem.tsx
+++ b/packages/upup/src/frontend/components/FileItem.tsx
@@ -59,6 +59,7 @@ export default memo(function FileItem({ file }: Props) {
                     fileType={file.type}
                     fileUrl={file.url}
                     fileName={file.name}
+                    fileSize={file.size}
                 />
             )}
         </div>

--- a/packages/upup/src/frontend/components/FilePreview.tsx
+++ b/packages/upup/src/frontend/components/FilePreview.tsx
@@ -9,11 +9,7 @@ import React, {
 } from 'react'
 
 import { useRootContext } from '../context/RootContext'
-import {
-    fileCanPreviewText,
-    fileGetIsImage,
-    fileGetIsText,
-} from '../lib/file'
+import { fileCanPreviewText, fileGetIsImage, fileGetIsText } from '../lib/file'
 import { cn } from '../lib/tailwind'
 import FilePreviewThumbnail from './FilePreviewThumbnail'
 import ProgressBar from './shared/ProgressBar'

--- a/packages/upup/src/frontend/components/FilePreview.tsx
+++ b/packages/upup/src/frontend/components/FilePreview.tsx
@@ -9,7 +9,11 @@ import React, {
 } from 'react'
 
 import { useRootContext } from '../context/RootContext'
-import { fileGetIsImage } from '../lib/file'
+import {
+    fileCanPreviewText,
+    fileGetIsImage,
+    fileGetIsText,
+} from '../lib/file'
 import { cn } from '../lib/tailwind'
 import FilePreviewThumbnail from './FilePreviewThumbnail'
 import ProgressBar from './shared/ProgressBar'
@@ -51,22 +55,16 @@ export default memo(function FilePreview(props: Props) {
     } = useRootContext()
 
     const isImage = useMemo(() => fileGetIsImage(fileType), [fileType])
-    const isText = useMemo(() => {
-        if (!fileType) return false
-        if (fileType.startsWith('text/')) return true
-        const lower = fileName.toLowerCase()
-        return (
-            lower.endsWith('.txt') ||
-            lower.endsWith('.md') ||
-            lower.endsWith('.json') ||
-            lower.endsWith('.csv') ||
-            lower.endsWith('.log') ||
-            lower.endsWith('.js') ||
-            lower.endsWith('.ts') ||
-            lower.endsWith('.css') ||
-            lower.endsWith('.html')
-        )
-    }, [fileType, fileName])
+    const isText = useMemo(
+        () => fileGetIsText(fileType, fileName),
+        [fileType, fileName],
+    )
+
+    // Only allow inline text preview for files within the safe size threshold
+    const canPreviewText = useMemo(
+        () => fileCanPreviewText(fileType, fileName, fileSize),
+        [fileType, fileName, fileSize],
+    )
 
     const progress = useMemo(
         () =>
@@ -79,8 +77,12 @@ export default memo(function FilePreview(props: Props) {
     )
 
     useEffect(() => {
-        if ((isImage || isText) && !canPreview) setCanPreview(true)
-    }, [isImage, isText, canPreview, setCanPreview])
+        // For text files, only set canPreview if below the safe size threshold.
+        // Large text files (e.g. 3MB+ JSON) would freeze the browser if rendered
+        // via <object> tags, so they get a static icon instead.
+        if ((isImage || (isText && canPreviewText)) && !canPreview)
+            setCanPreview(true)
+    }, [isImage, isText, canPreviewText, canPreview, setCanPreview])
 
     const onHandleFileRemove: MouseEventHandler<HTMLButtonElement> = e => {
         e.stopPropagation()
@@ -120,6 +122,7 @@ export default memo(function FilePreview(props: Props) {
                             fileType={fileType}
                             fileName={fileName}
                             fileUrl={fileUrl}
+                            fileSize={fileSize}
                             allowPreview={allowPreview}
                             classNames={classNames}
                         />

--- a/packages/upup/src/frontend/components/FilePreviewPortal.tsx
+++ b/packages/upup/src/frontend/components/FilePreviewPortal.tsx
@@ -9,7 +9,12 @@ import React, {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { useRootContext } from '../context/RootContext'
-import { fileGetIsImage } from '../lib/file'
+import {
+    fileGetIsImage,
+    fileGetIsText,
+    PREVIEW_MAX_TEXT_SIZE,
+    PREVIEW_TEXT_TRUNCATE_LENGTH,
+} from '../lib/file'
 import { cn } from '../lib/tailwind'
 import ShouldRender from './shared/ShouldRender'
 
@@ -21,35 +26,34 @@ export default memo(
             fileUrl: string
             fileName: string
             fileType: string
+            fileSize?: number
         }
     >(function FilePreviewPortal(
-        { onStopPropagation, fileUrl, fileName, fileType, ...restProps },
+        { onStopPropagation, fileUrl, fileName, fileType, fileSize, ...restProps },
         ref,
     ) {
         const {
             props: { dark, classNames },
         } = useRootContext()
         const isImage = useMemo(() => fileGetIsImage(fileType), [fileType])
-        const isText = useMemo(() => {
-            if (!fileType) return false
-            if (fileType.startsWith('text/')) return true
-            const lower = fileName.toLowerCase()
-            return (
-                lower.endsWith('.txt') ||
-                lower.endsWith('.md') ||
-                lower.endsWith('.json') ||
-                lower.endsWith('.csv') ||
-                lower.endsWith('.log') ||
-                lower.endsWith('.js') ||
-                lower.endsWith('.ts') ||
-                lower.endsWith('.css') ||
-                lower.endsWith('.html')
-            )
-        }, [fileType, fileName])
+        const isText = useMemo(
+            () => fileGetIsText(fileType, fileName),
+            [fileType, fileName],
+        )
+
+        const isOversizedText = useMemo(
+            () =>
+                isText &&
+                fileSize !== undefined &&
+                fileSize > PREVIEW_MAX_TEXT_SIZE,
+            [isText, fileSize],
+        )
 
         const [textContent, setTextContent] = useState<string>('')
         const [textLoading, setTextLoading] = useState(false)
         const [textError, setTextError] = useState<string>()
+
+        const [isTruncated, setIsTruncated] = useState(false)
 
         useEffect(() => {
             let cancelled = false
@@ -57,9 +61,41 @@ export default memo(
                 if (!isText) return
                 try {
                     setTextLoading(true)
-                    const res = await fetch(fileUrl)
-                    const txt = await res.text()
-                    if (!cancelled) setTextContent(txt)
+
+                    if (isOversizedText) {
+                        // For large text files, only read up to PREVIEW_TEXT_TRUNCATE_LENGTH
+                        // to avoid freezing the browser with massive DOM rendering
+                        const res = await fetch(fileUrl)
+                        const reader = res.body?.getReader()
+                        if (!reader) throw new Error('Cannot read file')
+
+                        const decoder = new TextDecoder()
+                        let result = ''
+                        let done = false
+
+                        while (!done && result.length < PREVIEW_TEXT_TRUNCATE_LENGTH) {
+                            const { value, done: streamDone } = await reader.read()
+                            done = streamDone
+                            if (value) {
+                                result += decoder.decode(value, { stream: !done })
+                            }
+                        }
+                        reader.cancel()
+
+                        if (!cancelled) {
+                            const wasTruncated =
+                                !done || result.length > PREVIEW_TEXT_TRUNCATE_LENGTH
+                            if (wasTruncated) {
+                                result = result.slice(0, PREVIEW_TEXT_TRUNCATE_LENGTH)
+                            }
+                            setIsTruncated(wasTruncated)
+                            setTextContent(result)
+                        }
+                    } else {
+                        const res = await fetch(fileUrl)
+                        const txt = await res.text()
+                        if (!cancelled) setTextContent(txt)
+                    }
                 } catch (e) {
                     if (!cancelled)
                         setTextError((e as Error)?.message || 'Preview error')
@@ -71,7 +107,7 @@ export default memo(
             return () => {
                 cancelled = true
             }
-        }, [fileUrl, isText])
+        }, [fileUrl, isText, isOversizedText])
 
         return createPortal(
             <div
@@ -104,9 +140,16 @@ export default memo(
                                     {textLoading && <p>Loading...</p>}
                                     {textError && <p>Error: {textError}</p>}
                                     {!textLoading && !textError && (
-                                        <pre className="upup-whitespace-pre-wrap">
-                                            {textContent}
-                                        </pre>
+                                        <>
+                                            <pre className="upup-whitespace-pre-wrap">
+                                                {textContent}
+                                            </pre>
+                                            {isTruncated && (
+                                                <div className="upup-mt-4 upup-rounded upup-border upup-border-yellow-500/30 upup-bg-yellow-500/10 upup-px-3 upup-py-2 upup-text-xs upup-text-yellow-400">
+                                                    Content truncated — file is too large to preview in full.
+                                                </div>
+                                            )}
+                                        </>
                                     )}
                                 </div>
                             </ShouldRender>

--- a/packages/upup/src/frontend/components/FilePreviewPortal.tsx
+++ b/packages/upup/src/frontend/components/FilePreviewPortal.tsx
@@ -29,7 +29,14 @@ export default memo(
             fileSize?: number
         }
     >(function FilePreviewPortal(
-        { onStopPropagation, fileUrl, fileName, fileType, fileSize, ...restProps },
+        {
+            onStopPropagation,
+            fileUrl,
+            fileName,
+            fileType,
+            fileSize,
+            ...restProps
+        },
         ref,
     ) {
         const {
@@ -73,20 +80,30 @@ export default memo(
                         let result = ''
                         let done = false
 
-                        while (!done && result.length < PREVIEW_TEXT_TRUNCATE_LENGTH) {
-                            const { value, done: streamDone } = await reader.read()
+                        while (
+                            !done &&
+                            result.length < PREVIEW_TEXT_TRUNCATE_LENGTH
+                        ) {
+                            const { value, done: streamDone } =
+                                await reader.read()
                             done = streamDone
                             if (value) {
-                                result += decoder.decode(value, { stream: !done })
+                                result += decoder.decode(value, {
+                                    stream: !done,
+                                })
                             }
                         }
                         reader.cancel()
 
                         if (!cancelled) {
                             const wasTruncated =
-                                !done || result.length > PREVIEW_TEXT_TRUNCATE_LENGTH
+                                !done ||
+                                result.length > PREVIEW_TEXT_TRUNCATE_LENGTH
                             if (wasTruncated) {
-                                result = result.slice(0, PREVIEW_TEXT_TRUNCATE_LENGTH)
+                                result = result.slice(
+                                    0,
+                                    PREVIEW_TEXT_TRUNCATE_LENGTH,
+                                )
                             }
                             setIsTruncated(wasTruncated)
                             setTextContent(result)
@@ -146,7 +163,9 @@ export default memo(
                                             </pre>
                                             {isTruncated && (
                                                 <div className="upup-mt-4 upup-rounded upup-border upup-border-yellow-500/30 upup-bg-yellow-500/10 upup-px-3 upup-py-2 upup-text-xs upup-text-yellow-400">
-                                                    Content truncated — file is too large to preview in full.
+                                                    Content truncated — file is
+                                                    too large to preview in
+                                                    full.
                                                 </div>
                                             )}
                                         </>

--- a/packages/upup/src/frontend/components/FilePreviewPortal.tsx
+++ b/packages/upup/src/frontend/components/FilePreviewPortal.tsx
@@ -127,63 +127,65 @@ export default memo(
         }, [fileUrl, isText, isOversizedText])
 
         return createPortal(
-            <div
-                className="upup-fixed upup-inset-0 upup-z-[2147483647] upup-flex upup-items-center upup-justify-center upup-bg-black/40"
-                ref={ref}
-                {...restProps}
-            >
-                <div className="upup-relative upup-h-[90vh] upup-w-[90vw] upup-p-4">
-                    <div
-                        className={cn(
-                            'upup-absolute upup-inset-0 upup-m-4 upup-bg-white',
-                            {
-                                'upup-bg-[#232323] dark:upup-bg-[#232323]':
-                                    dark,
-                            },
-                            classNames.filePreviewPortal,
-                        )}
-                        onClick={onStopPropagation}
-                    >
-                        <ShouldRender if={isImage}>
-                            <img
-                                src={fileUrl}
-                                alt={fileName}
-                                className="upup-h-full upup-w-full upup-rounded upup-object-contain"
-                            />
-                        </ShouldRender>
-                        <ShouldRender if={!isImage}>
-                            <ShouldRender if={isText}>
-                                <div className="upup-h-full upup-w-full upup-overflow-auto upup-p-4 upup-font-mono upup-text-xs">
-                                    {textLoading && <p>Loading...</p>}
-                                    {textError && <p>Error: {textError}</p>}
-                                    {!textLoading && !textError && (
-                                        <>
-                                            <pre className="upup-whitespace-pre-wrap">
-                                                {textContent}
-                                            </pre>
-                                            {isTruncated && (
-                                                <div className="upup-mt-4 upup-rounded upup-border upup-border-yellow-500/30 upup-bg-yellow-500/10 upup-px-3 upup-py-2 upup-text-xs upup-text-yellow-400">
-                                                    Content truncated — file is
-                                                    too large to preview in
-                                                    full.
-                                                </div>
-                                            )}
-                                        </>
-                                    )}
-                                </div>
+            <div className="upup-scope">
+                <div
+                    className="upup-fixed upup-inset-0 upup-z-[2147483647] upup-flex upup-items-center upup-justify-center upup-bg-black/40"
+                    ref={ref}
+                    {...restProps}
+                >
+                    <div className="upup-relative upup-h-[90vh] upup-w-[90vw] upup-p-4">
+                        <div
+                            className={cn(
+                                'upup-absolute upup-inset-0 upup-m-4 upup-bg-white',
+                                {
+                                    'upup-bg-[#232323] dark:upup-bg-[#232323]':
+                                        dark,
+                                },
+                                classNames.filePreviewPortal,
+                            )}
+                            onClick={onStopPropagation}
+                        >
+                            <ShouldRender if={isImage}>
+                                <img
+                                    src={fileUrl}
+                                    alt={fileName}
+                                    className="upup-h-full upup-w-full upup-rounded upup-object-contain"
+                                />
                             </ShouldRender>
-                            <ShouldRender if={!isText}>
-                                <object
-                                    data={fileUrl}
-                                    width="100%"
-                                    height="100%"
-                                    name={fileName}
-                                    type={fileType}
-                                >
-                                    <p>Loading...</p>
-                                </object>
+                            <ShouldRender if={!isImage}>
+                                <ShouldRender if={isText}>
+                                    <div className="upup-h-full upup-w-full upup-overflow-auto upup-p-4 upup-font-mono upup-text-xs">
+                                        {textLoading && <p>Loading...</p>}
+                                        {textError && <p>Error: {textError}</p>}
+                                        {!textLoading && !textError && (
+                                            <>
+                                                <pre className="upup-whitespace-pre-wrap">
+                                                    {textContent}
+                                                </pre>
+                                                {isTruncated && (
+                                                    <div className="upup-mt-4 upup-rounded upup-border upup-border-yellow-500/30 upup-bg-yellow-500/10 upup-px-3 upup-py-2 upup-text-xs upup-text-yellow-400">
+                                                        Content truncated — file
+                                                        is too large to preview
+                                                        in full.
+                                                    </div>
+                                                )}
+                                            </>
+                                        )}
+                                    </div>
+                                </ShouldRender>
+                                <ShouldRender if={!isText}>
+                                    <object
+                                        data={fileUrl}
+                                        width="100%"
+                                        height="100%"
+                                        name={fileName}
+                                        type={fileType}
+                                    >
+                                        <p>Loading...</p>
+                                    </object>
+                                </ShouldRender>
                             </ShouldRender>
-                        </ShouldRender>
+                        </div>
                     </div>
                 </div>
             </div>,

--- a/packages/upup/src/frontend/components/FilePreviewThumbnail.tsx
+++ b/packages/upup/src/frontend/components/FilePreviewThumbnail.tsx
@@ -1,6 +1,11 @@
 import React, { Dispatch, SetStateAction, memo, useMemo } from 'react'
 import { UpupUploaderPropsClassNames } from '../../shared/types'
-import { fileCanPreviewText, fileGetExtension, fileGetIsText, fileIs3D } from '../lib/file'
+import {
+    fileCanPreviewText,
+    fileGetExtension,
+    fileGetIsText,
+    fileIs3D,
+} from '../lib/file'
 import { cn } from '../lib/tailwind'
 import FileIcon from './FileIcon'
 import ShouldRender from './shared/ShouldRender'

--- a/packages/upup/src/frontend/components/FilePreviewThumbnail.tsx
+++ b/packages/upup/src/frontend/components/FilePreviewThumbnail.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, memo, useMemo } from 'react'
 import { UpupUploaderPropsClassNames } from '../../shared/types'
-import { fileGetExtension, fileIs3D } from '../lib/file'
+import { fileCanPreviewText, fileGetExtension, fileGetIsText, fileIs3D } from '../lib/file'
 import { cn } from '../lib/tailwind'
 import FileIcon from './FileIcon'
 import ShouldRender from './shared/ShouldRender'
@@ -11,6 +11,7 @@ type Props = {
     fileType: string
     fileName: string
     fileUrl: string
+    fileSize?: number
     classNames: UpupUploaderPropsClassNames
     allowPreview: boolean
 }
@@ -22,6 +23,7 @@ export default memo(
         fileUrl,
         fileName,
         fileType,
+        fileSize,
         classNames,
         allowPreview,
     }: Props) {
@@ -34,7 +36,15 @@ export default memo(
             return fileIs3D(extension?.toLowerCase() || '')
         }, [extension])
 
-        if (is3D) {
+        // Large text files (e.g. 3MB+ JSON) must not be rendered via <object> tags
+        // as the browser will attempt to parse and lay out the entire content,
+        // blocking the main thread and freezing the page.
+        const isOversizedText = useMemo(() => {
+            const isText = fileGetIsText(fileType, fileName)
+            return isText && !fileCanPreviewText(fileType, fileName, fileSize)
+        }, [fileType, fileName, fileSize])
+
+        if (is3D || isOversizedText) {
             return (
                 <div className="upup-flex upup-flex-col upup-items-center upup-gap-2">
                     <FileIcon

--- a/packages/upup/src/frontend/components/shared/MainBoxHeader.tsx
+++ b/packages/upup/src/frontend/components/shared/MainBoxHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { UploadStatus, useRootContext } from '../../context/RootContext'
 import { cn } from '../../lib/tailwind'
 import ShouldRender from './ShouldRender'
@@ -11,7 +11,6 @@ export default function MainBoxHeader({ handleCancel }: Readonly<Props>) {
     const {
         files,
         setIsAddingMore,
-        isAddingMore,
         props: {
             mini,
             limit,
@@ -24,10 +23,6 @@ export default function MainBoxHeader({ handleCancel }: Readonly<Props>) {
     } = useRootContext()
     const isUploading = uploadStatus === UploadStatus.ONGOING
     const isLimitReached = limit === files.size
-    const cancelText = useMemo(
-        () => (isAddingMore ? 'Cancel' : 'Remove all files'),
-        [isAddingMore],
-    )
 
     if (mini) return null
 
@@ -52,7 +47,7 @@ export default function MainBoxHeader({ handleCancel }: Readonly<Props>) {
                 onClick={handleCancel}
                 disabled={isUploading || isProcessing}
             >
-                {cancelText}
+                Remove all files
             </button>
             <span
                 className={cn(
@@ -62,12 +57,9 @@ export default function MainBoxHeader({ handleCancel }: Readonly<Props>) {
                     },
                 )}
             >
-                <ShouldRender if={isAddingMore}>Adding more files</ShouldRender>
-                <ShouldRender if={!isAddingMore}>
-                    {files.size} file{files.size > 1 ? 's' : ''} selected
-                </ShouldRender>
+                {files.size} file{files.size > 1 ? 's' : ''} selected
             </span>
-            <ShouldRender if={!isAddingMore && limit > 1 && !isLimitReached}>
+            <ShouldRender if={limit > 1 && !isLimitReached}>
                 <button
                     className={cn(
                         'upup-col-start-3 upup-col-end-5 upup-flex upup-items-center upup-justify-end upup-gap-1 upup-rounded-md upup-border upup-border-dashed upup-border-blue-400/50 upup-px-2 upup-py-1 upup-text-sm upup-text-blue-600 md:upup-col-start-4',

--- a/packages/upup/src/frontend/lib/file.ts
+++ b/packages/upup/src/frontend/lib/file.ts
@@ -125,6 +125,52 @@ export function fileGetIsImage(fileType: string) {
     return fileType.startsWith('image/')
 }
 
+/**
+ * Maximum file size (in bytes) for which text-based preview is allowed.
+ * Files exceeding this threshold will show a static icon instead of rendering content,
+ * preventing the browser from freezing on large text files (e.g. 3MB+ JSON).
+ */
+export const PREVIEW_MAX_TEXT_SIZE = 512 * 1024 // 512 KB
+
+/**
+ * Maximum number of characters to render in the preview portal for text files.
+ * Content beyond this limit is truncated with an indicator.
+ */
+export const PREVIEW_TEXT_TRUNCATE_LENGTH = 100_000 // ~100 KB of text
+
+/**
+ * Determines whether a file is a text-based file that could be previewed as text.
+ */
+export function fileGetIsText(fileType: string, fileName: string): boolean {
+    if (!fileType) return false
+    if (fileType.startsWith('text/')) return true
+    const lower = fileName.toLowerCase()
+    return (
+        lower.endsWith('.txt') ||
+        lower.endsWith('.md') ||
+        lower.endsWith('.json') ||
+        lower.endsWith('.csv') ||
+        lower.endsWith('.log') ||
+        lower.endsWith('.js') ||
+        lower.endsWith('.ts') ||
+        lower.endsWith('.css') ||
+        lower.endsWith('.html')
+    )
+}
+
+/**
+ * Returns true if a text file is small enough to safely preview inline.
+ */
+export function fileCanPreviewText(
+    fileType: string,
+    fileName: string,
+    fileSize: number | undefined,
+): boolean {
+    if (!fileGetIsText(fileType, fileName)) return false
+    if (fileSize === undefined) return true // unknown size, allow preview
+    return fileSize <= PREVIEW_MAX_TEXT_SIZE
+}
+
 export function fileGetExtension(fileType: string, fileName: string) {
     if (!fileType) {
         return fileName.split('.').pop()?.toLowerCase() || ''


### PR DESCRIPTION
# Fix Previewing Bugs

## Fixes the following issues/bugs:
- Browser hangs/freezes (and the user is unable to perform any actions on the page) when a large file, approx 3MB+ (that requires previewing, e.g, a JSON file) is uploaded.
- Unclear and potentially confusing "Cancel Adding more files" instructional text when a user is in the "Add more files" mode after clicking the "Add more files" button.

## Type of change
- fix: add max threshold (~ 512KB) for files that require preview, i.e, files larger than ~512KB will not be previewed
- fix: replace "Cancel Adding more files" instructional text with:
    - "Back" button and centered "Adding more files" text which serves 2 functions:
        - Gives the user an exit to navigate back to the previous step before they clicked the "Add more files" button
        - Tells the user that they're currently in the "Add more files" mode