### PR TITLE
ci: pin pnpm to 10.11.0 (fixes CI crash on Node 20)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PNPM environment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          npm install -g pnpm@latest
+          npm install -g pnpm@10.11.0
           pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache PNPM dependencies
@@ -57,7 +57,7 @@ jobs:
       - name: Setup PNPM environment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          npm install -g pnpm@latest
+          npm install -g pnpm@10.11.0
           pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache PNPM dependencies
@@ -135,7 +135,7 @@ jobs:
       - name: Setup PNPM environment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          npm install -g pnpm@latest
+          npm install -g pnpm@10.11.0
           pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache PNPM dependencies
@@ -187,7 +187,7 @@ jobs:
       - name: Setup PNPM environment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          npm install -g pnpm@latest
+          npm install -g pnpm@10.11.0
           pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache PNPM dependencies


### PR DESCRIPTION
## Problem

All CI checks currently fail during the **"Setup PNPM environment"** step, before any job's real work runs:

```
npm install -g pnpm@latest            # now resolves to pnpm 11.12.0
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
##[error]Process completed with exit code 1.
```

`pnpm@latest` bumped to v11, which requires **Node ≥ 22.13**, but CI pins **Node 20.18.2** via `.nvmrc`. pnpm 11 does `require('node:sqlite')` (only in Node ≥ 22) → crash. This is time-based drift and breaks **every** PR's checks (Prettier Check → Status Check) with an error unrelated to the diff under review.

## Fix

Pin the workflow's pnpm to **`10.11.0`** — the repo's own declared `packageManager` (root `package.json`) — at all 4 setup steps in `.github/workflows/main.yml` (`npm install -g pnpm@latest` → `npm install -g pnpm@10.11.0`).

- Minimal: 4 one-line changes, one file.
- `.nvmrc` (Node 20) intentionally left unchanged to keep runtime blast radius minimal.
- No other workflow uses `pnpm@latest` (checked `publish.yml`/`e2e.yml`/`nightly.yml`).

## Verify

`grep` of `main.yml` after the change: `pnpm@latest` = 0, `pnpm@10.11.0` = 4 (lines 26/60/138/190). Locally, `pnpm@10.11.0` (the repo's pinned version) runs CI scripts fine on Node 20 (`pnpm run prettier-check` → exit 0).

Do not merge yet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
