### PR TITLE
ci(release): umbrella GitHub Release with changelog, contributors + npm links

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,23 @@
 {
     "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-    "changelog": false,
+    "changelog": [
+        "@changesets/changelog-github",
+        { "repo": "DevinoSolutions/upup" }
+    ],
     "commit": false,
-    "fixed": [],
+    "fixed": [
+        [
+            "@upupjs/angular",
+            "@upupjs/core",
+            "@upupjs/next",
+            "@upupjs/preact",
+            "@upupjs/react",
+            "@upupjs/server",
+            "@upupjs/svelte",
+            "@upupjs/vanilla",
+            "@upupjs/vue"
+        ]
+    ],
     "linked": [],
     "access": "public",
     "baseBranch": "master",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ jobs:
         steps:
             - name: Checkout repo
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  # Full history + tags: the umbrella-release step derives contributors
+                  # (git shortlog over the range) and the previous v-tag from them.
+                  fetch-depth: 0
 
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4.4.0
 
@@ -141,14 +145,40 @@ jobs:
               if: github.ref == 'refs/heads/dev'
               run: pnpm run test-release
 
-            - name: Create GitHub Releases (per published package)
+            - name: Push package tags + publish umbrella GitHub Release
               if: github.ref == 'refs/heads/master' && steps.changesets.outputs.hasChangesets == 'false' && steps.package_meta.outputs.any_needs_publish == 'true'
               shell: bash
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  TO_PUBLISH: ${{ steps.package_meta.outputs.to_publish }}
               run: |
-                  for ref in $TO_PUBLISH; do
-                    case "$ref" in *[!A-Za-z0-9@._/-]*) echo "skip invalid ref: $ref"; continue;; esac
-                    gh release create "$ref" --title "$ref" --generate-notes || true
-                  done
+                  # changeset publish tagged each package locally (@upupjs/x@ver) — push them
+                  # so the per-package tags exist on the remote (but no per-package *releases*).
+                  git push origin --tags || echo "::warning::pushing package tags failed"
+
+                  VERSION="$(node -p "require('./packages/core/package.json').version")"
+                  TAG="v$VERSION"
+                  if gh release view "$TAG" >/dev/null 2>&1; then
+                    echo "Release $TAG already exists — nothing to do."
+                    exit 0
+                  fi
+
+                  # Previous v-release → compare link + GitHub's auto "What's Changed" body.
+                  PREV_TAG="$(git tag -l 'v*' --sort=-v:refname | grep -vx "$TAG" | head -1 || true)"
+                  NOTES="$RUNNER_TEMP/release-notes.md"
+                  CHANGELOG="$RUNNER_TEMP/changelog.md"
+                  : >"$CHANGELOG"
+                  if [ -n "$PREV_TAG" ]; then
+                    gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+                      -f tag_name="$TAG" -f previous_tag_name="$PREV_TAG" -f target_commitish="$GITHUB_SHA" \
+                      --jq '.body' >"$CHANGELOG" || : >"$CHANGELOG"
+                  fi
+
+                  NOTE_ARGS=(--version "$VERSION" --changelog "$CHANGELOG")
+                  if [ -n "$PREV_TAG" ]; then NOTE_ARGS+=(--previous-tag "$PREV_TAG"); fi
+                  node scripts/generate-release-notes.mjs "${NOTE_ARGS[@]}" >"$NOTES"
+
+                  gh release create "$TAG" \
+                    --title "upup $TAG" \
+                    --notes-file "$NOTES" \
+                    --target "$GITHUB_SHA" \
+                    --latest

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test": "turbo run test --continue",
         "test:coverage": "turbo run test:coverage --continue",
         "test:quality": "node scripts/ci/test-quality-guard.mjs",
-        "test:scripts": "node --test scripts/ci/test-quality-guard.test.mjs scripts/ci/resolve-affected-tests.test.mjs scripts/lib/tarball.test.mjs",
+        "test:scripts": "node --test scripts/ci/test-quality-guard.test.mjs scripts/ci/resolve-affected-tests.test.mjs scripts/lib/tarball.test.mjs scripts/lib/release-notes.test.mjs",
         "e2e": "turbo run build && pnpm --filter @upupjs/e2e-test test:e2e && dotenv -e local-dev/.env.minio -- pnpm --filter @upupjs/e2e-test test:e2e:cf",
         "e2e:a11y": "turbo run build && pnpm --filter @upupjs/e2e-test test:e2e:a11y",
         "e2e:minio:up": "dotenv -e local-dev/.env.minio -- node scripts/validate-env.mjs && dotenv -e local-dev/.env.minio -- docker compose up -d",
@@ -50,6 +50,7 @@
         "test-release": "pnpm run build:package && pnpm -r publish --dry-run --no-git-checks"
     },
     "devDependencies": {
+        "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.30.0",
         "@napi-rs/canvas": "^1.0.2",
         "@size-limit/file": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.1
+        version: 0.5.2(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@25.3.5)
@@ -576,11 +579,11 @@ importers:
         version: link:../../packages/preact
       preact:
         specifier: ^10.29.2
-        version: 10.29.2
+        version: 10.29.7(preact-render-to-string@6.7.0)
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.9.0
-        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@3.29.5)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.7)(rollup@3.29.5)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/addon-a11y':
         specifier: ^9
         version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
@@ -592,7 +595,7 @@ importers:
         version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@storybook/preact-vite':
         specifier: ^9
-        version: 9.1.20(preact@10.29.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 9.1.20(preact@10.29.7)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@upupjs/storybook-config':
         specifier: workspace:*
         version: link:../../packages/storybook-config
@@ -1140,7 +1143,7 @@ importers:
     devDependencies:
       '@testing-library/preact':
         specifier: ^3.2.4
-        version: 3.2.4(preact@10.29.2)
+        version: 3.2.4(preact@10.29.7)
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
@@ -1167,10 +1170,10 @@ importers:
         version: 10.3.0
       preact:
         specifier: ^10.29.2
-        version: 10.29.2
+        version: 10.29.7(preact-render-to-string@6.7.0)
       preact-render-to-string:
         specifier: ^6.5.0
-        version: 6.7.0(preact@10.29.2)
+        version: 6.7.0(preact@10.29.7)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -2848,6 +2851,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.5.2':
+    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
+
   '@changesets/cli@2.30.0':
     resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
     hasBin: true
@@ -2860,6 +2866,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.7.0':
+    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
 
   '@changesets/get-release-plan@4.0.15':
     resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
@@ -8950,6 +8959,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -9216,6 +9228,10 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -12034,6 +12050,15 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
@@ -13072,9 +13097,6 @@ packages:
     resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
-
-  preact@10.29.2:
-    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   preact@10.29.7:
     resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
@@ -14712,6 +14734,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -15388,6 +15413,9 @@ packages:
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -15552,6 +15580,9 @@ packages:
   whatwg-url@12.0.1:
     resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
     engines: {node: '>=14'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -18713,6 +18744,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.2(encoding@0.1.13)':
+    dependencies:
+      '@changesets/get-github-info': 0.7.0(encoding@0.1.13)
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.30.0(@types/node@25.3.5)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
@@ -18765,6 +18804,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
+
+  '@changesets/get-github-info@0.7.0(encoding@0.1.13)':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.6.7(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
@@ -22452,12 +22498,12 @@ snapshots:
 
   '@posthog/types@1.394.0': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@3.29.5)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.7)(rollup@3.29.5)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.7)
-      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@prefresh/vite': 2.4.12(preact@10.29.7)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@3.29.5)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.7)
       debug: 4.4.3
@@ -22473,20 +22519,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.3': {}
 
-  '@prefresh/core@1.5.10(preact@10.29.2)':
+  '@prefresh/core@1.5.10(preact@10.29.7)':
     dependencies:
-      preact: 10.29.2
+      preact: 10.29.7(preact-render-to-string@6.7.0)
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.7)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
-      '@prefresh/core': 1.5.10(preact@10.29.2)
+      '@prefresh/core': 1.5.10(preact@10.29.7)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 10.29.2
+      preact: 10.29.7(preact-render-to-string@6.7.0)
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -23394,19 +23440,19 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/preact-vite@9.1.20(preact@10.29.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@storybook/preact-vite@9.1.20(preact@10.29.7)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@storybook/preact': 9.1.20(preact@10.29.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
-      preact: 10.29.2
+      '@storybook/preact': 9.1.20(preact@10.29.7)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
+      preact: 10.29.7(preact-render-to-string@6.7.0)
       storybook: 9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - vite
 
-  '@storybook/preact@9.1.20(preact@10.29.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@storybook/preact@9.1.20(preact@10.29.7)(storybook@9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@storybook/global': 5.0.0
-      preact: 10.29.2
+      preact: 10.29.7(preact-render-to-string@6.7.0)
       storybook: 9.1.20(@testing-library/dom@10.4.0)(msw@2.14.6(@types/node@25.3.5)(typescript@5.6.3))(prettier@3.9.4)(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       ts-dedent: 2.2.0
 
@@ -23821,10 +23867,10 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/preact@3.2.4(preact@10.29.2)':
+  '@testing-library/preact@3.2.4(preact@10.29.7)':
     dependencies:
       '@testing-library/dom': 8.20.1
-      preact: 10.29.2
+      preact: 10.29.7(preact-render-to-string@6.7.0)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -26569,6 +26615,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dataloader@1.4.0: {}
+
   dateformat@4.6.3: {}
 
   dayjs@1.11.19: {}
@@ -26824,6 +26872,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
+
+  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -30574,6 +30624,12 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
+  node-fetch@2.6.7(encoding@0.1.13):
+    dependencies:
+      whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
+
   node-forge@1.3.1: {}
 
   node-gyp-build-optional-packages@5.2.2:
@@ -31790,16 +31846,9 @@ snapshots:
     dependencies:
       three: 0.178.0
 
-  preact-render-to-string@6.7.0(preact@10.29.2):
-    dependencies:
-      preact: 10.29.2
-
   preact-render-to-string@6.7.0(preact@10.29.7):
     dependencies:
       preact: 10.29.7(preact-render-to-string@6.7.0)
-    optional: true
-
-  preact@10.29.2: {}
 
   preact@10.29.7(preact-render-to-string@6.7.0):
     optionalDependencies:
@@ -33898,6 +33947,8 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tr46@0.0.3: {}
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -34835,6 +34886,8 @@ snapshots:
 
   web-vitals@5.3.0: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
@@ -35394,6 +35447,11 @@ snapshots:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Emit the umbrella GitHub Release notes for a upup release to stdout.
+//
+// Gathers the publishable @upupjs/* set (packages/*/package.json), the release
+// version (an anchor package or --version), the previous v-tag (git or
+// --previous-tag), and contributors (git shortlog over the range), then hands
+// everything to buildReleaseNotes() in scripts/lib/release-notes.mjs.
+//
+// Usage:
+//   node scripts/generate-release-notes.mjs [options] > notes.md
+//     --version <x.y.z>       release version (default: anchor package version)
+//     --previous-tag <tag>    prior release tag (default: latest v* tag != this)
+//     --highlights <file>     Markdown prepended verbatim as the intro
+//     --changelog <file>      "what's changed" body (e.g. GitHub auto-notes)
+//     --repo <owner/name>     default DevinoSolutions/upup
+//     --include-bots          keep [bot] authors in the contributor list
+//
+// Side effects: reads files + runs `git`. Never writes; never calls the network.
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { buildReleaseNotes } from './lib/release-notes.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const ANCHOR_PACKAGE = '@upupjs/core'
+
+function parseArgs(argv) {
+    const flags = { includeBots: false }
+    const opts = {}
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]
+        if (a === '--include-bots') flags.includeBots = true
+        else if (a.startsWith('--')) opts[a.slice(2)] = argv[++i]
+    }
+    return { ...opts, ...flags }
+}
+
+/** Read every publishable @upupjs/* package (name + version), sorted by name. */
+function readPublishablePackages() {
+    const dir = join(ROOT, 'packages')
+    const packages = []
+    for (const entry of readdirSync(dir)) {
+        let pkg
+        try {
+            pkg = JSON.parse(
+                readFileSync(join(dir, entry, 'package.json'), 'utf8'),
+            )
+        } catch {
+            continue
+        }
+        if (pkg.name?.startsWith('@upupjs/') && !pkg.private) {
+            packages.push({ name: pkg.name, version: pkg.version })
+        }
+    }
+    return packages.toSorted((a, b) => a.name.localeCompare(b.name))
+}
+
+function git(args) {
+    return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim()
+}
+
+/** Latest `v*` tag that is not the tag we're about to cut. */
+function detectPreviousTag(currentTag) {
+    let tags = ''
+    try {
+        tags = git(['tag', '-l', 'v*', '--sort=-v:refname'])
+    } catch {
+        return null
+    }
+    for (const t of tags.split('\n').filter(Boolean)) {
+        if (t !== currentTag) return t
+    }
+    return null
+}
+
+/**
+ * Contributors over `<previousTag>..HEAD` (or all history), deduped by email,
+ * bots dropped unless --include-bots, ranked by commit count.
+ */
+function gatherContributors(previousTag, includeBots) {
+    const range = previousTag ? `${previousTag}..HEAD` : 'HEAD'
+    let raw = ''
+    try {
+        raw = git(['shortlog', '-sne', '--no-merges', range])
+    } catch {
+        return [] // shallow clone / missing tag → skip the section, never crash
+    }
+    const byEmail = new Map()
+    for (const line of raw.split('\n')) {
+        const m = line.match(/^\s*(\d+)\s+(.+?)\s+<([^>]+)>$/)
+        if (!m) continue
+        const [, count, name, email] = m
+        const isBot = /\[bot\]/i.test(name) || /\[bot\]/i.test(email)
+        if (isBot && !includeBots) continue
+        const prev = byEmail.get(email)
+        if (prev) prev.commits += Number(count)
+        else byEmail.set(email, { name, commits: Number(count) })
+    }
+    return [...byEmail.values()].toSorted((a, b) => b.commits - a.commits)
+}
+
+function readOptionalFile(path) {
+    if (!path) return ''
+    try {
+        return readFileSync(path, 'utf8')
+    } catch {
+        return ''
+    }
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2))
+    const packages = readPublishablePackages()
+    if (!packages.length) {
+        console.error(
+            'generate-release-notes: no publishable @upupjs/* packages found',
+        )
+        process.exit(1)
+    }
+
+    const anchor = packages.find(p => p.name === ANCHOR_PACKAGE) ?? packages[0]
+    const version = args.version ?? anchor.version
+    const tag = args.tag ?? `v${version}`
+    const previousTag = args['previous-tag'] ?? detectPreviousTag(tag)
+
+    const notes = buildReleaseNotes({
+        version,
+        tag,
+        repo: args.repo ?? 'DevinoSolutions/upup',
+        packages,
+        contributors: gatherContributors(previousTag, args.includeBots),
+        previousTag,
+        highlights: readOptionalFile(args.highlights),
+        changelog: readOptionalFile(args.changelog),
+    })
+    process.stdout.write(notes)
+}
+
+main()

--- a/scripts/lib/release-notes.mjs
+++ b/scripts/lib/release-notes.mjs
@@ -1,0 +1,135 @@
+// Pure builders for the umbrella GitHub Release notes (one `v<version>` release
+// covering every published @upupjs/* package). Kept side-effect-free so
+// scripts/lib/release-notes.test.mjs can pin the exact Markdown; the CLI
+// (scripts/generate-release-notes.mjs) gathers the inputs (fs + git) and calls
+// buildReleaseNotes(). All @upupjs/* packages are `fixed` in changesets, so a
+// release shares ONE version — but the packages table still prints each
+// package's own version, so any accidental divergence stays visible.
+
+const NPM_ORG_URL = 'https://www.npmjs.com/org/upupjs'
+
+/** npm version-pinned package page, e.g. .../package/@upupjs/core/v/3.1.0 */
+export function npmPackageUrl(name, version) {
+    return `https://www.npmjs.com/package/${name}/v/${version}`
+}
+
+/** GitHub compare link between two refs. */
+export function compareUrl(repo, previousTag, tag) {
+    return `https://github.com/${repo}/compare/${previousTag}...${tag}`
+}
+
+function packagesSection(packages) {
+    const rows = packages
+        .map(
+            p =>
+                `| [\`${p.name}\`](${npmPackageUrl(p.name, p.version)}) | \`${p.version}\` |`,
+        )
+        .join('\n')
+    return [
+        '## 📦 Packages',
+        '',
+        `All ${packages.length} packages are published to npm under the [\`@upupjs\`](${NPM_ORG_URL}) scope:`,
+        '',
+        '| Package | Version |',
+        '| --- | --- |',
+        rows,
+    ].join('\n')
+}
+
+function installSection() {
+    return [
+        '## 📥 Install',
+        '',
+        '```bash',
+        '# pick your framework',
+        'npm i @upupjs/react     # or @upupjs/vue · @upupjs/svelte · @upupjs/angular · @upupjs/vanilla · @upupjs/preact',
+        '',
+        '# server mode — presign + proxy uploads to any S3-compatible storage',
+        'npm i @upupjs/server    # plus @upupjs/next for Next.js route handlers',
+        '```',
+    ].join('\n')
+}
+
+function changelogSection({ repo, previousTag, tag, changelog }) {
+    const parts = []
+    const body = (changelog || '').trim()
+    if (body) parts.push(body)
+    if (previousTag) {
+        parts.push(
+            `**Full changelog:** [\`${previousTag}...${tag}\`](${compareUrl(repo, previousTag, tag)})`,
+        )
+    }
+    if (!parts.length) return ''
+    return ['## 📝 What’s changed', '', parts.join('\n\n')].join('\n')
+}
+
+/** Render one contributor line: prefer a GitHub @handle, else the git name. */
+export function contributorLine(contributor) {
+    const who = contributor.handle ? `@${contributor.handle}` : contributor.name
+    if (!contributor.commits) return `- ${who}`
+    const plural = contributor.commits === 1 ? 'commit' : 'commits'
+    return `- ${who} — ${contributor.commits} ${plural}`
+}
+
+function contributorsSection(contributors) {
+    if (!contributors.length) return ''
+    return [
+        '## 👥 Contributors',
+        '',
+        'Thanks to everyone who shipped this release:',
+        '',
+        contributors.map(contributorLine).join('\n'),
+    ].join('\n')
+}
+
+/**
+ * Assemble the full release-notes Markdown from already-gathered inputs.
+ *
+ * @param {object}   o
+ * @param {string}   o.version        e.g. "3.1.0" (no leading v)
+ * @param {string}   [o.tag]          defaults to `v${version}`
+ * @param {string}   [o.repo]         "owner/name"
+ * @param {Array<{name:string,version:string}>} o.packages  publishable set
+ * @param {Array<{name?:string,handle?:string,commits?:number}>} [o.contributors]
+ * @param {string|null} [o.previousTag]  prior release tag for the compare link
+ * @param {string}   [o.highlights]   curated Markdown prepended verbatim
+ * @param {string}   [o.changelog]    "what's changed" body (e.g. GitHub auto-notes)
+ * @param {string}   [o.siteUrl]      docs URL for the footer
+ * @returns {string} Markdown (trailing newline)
+ */
+export function buildReleaseNotes({
+    version,
+    tag,
+    repo = 'DevinoSolutions/upup',
+    packages = [],
+    contributors = [],
+    previousTag = null,
+    highlights = '',
+    changelog = '',
+    siteUrl = 'https://useupup.com',
+}) {
+    if (!version) throw new Error('buildReleaseNotes: `version` is required')
+    if (!packages.length)
+        throw new Error('buildReleaseNotes: `packages` must not be empty')
+    const resolvedTag = tag || `v${version}`
+
+    const sections = []
+    const preamble = (highlights || '').trim()
+    if (preamble) sections.push(preamble)
+    sections.push(packagesSection(packages))
+    sections.push(installSection())
+    const changes = changelogSection({
+        repo,
+        previousTag,
+        tag: resolvedTag,
+        changelog,
+    })
+    if (changes) sections.push(changes)
+    const credits = contributorsSection(contributors)
+    if (credits) sections.push(credits)
+    sections.push(
+        `---\n\n📖 [Docs](${siteUrl}) · 🐙 [${repo}](https://github.com/${repo}) · MIT licensed`,
+    )
+
+    return sections.join('\n\n') + '\n'
+}

--- a/scripts/lib/release-notes.test.mjs
+++ b/scripts/lib/release-notes.test.mjs
@@ -1,0 +1,89 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+    buildReleaseNotes,
+    npmPackageUrl,
+    compareUrl,
+    contributorLine,
+} from './release-notes.mjs'
+
+const PKGS = [
+    { name: '@upupjs/core', version: '3.1.0' },
+    { name: '@upupjs/react', version: '3.1.0' },
+]
+
+test('npmPackageUrl pins the version', () => {
+    assert.equal(
+        npmPackageUrl('@upupjs/core', '3.1.0'),
+        'https://www.npmjs.com/package/@upupjs/core/v/3.1.0',
+    )
+})
+
+test('compareUrl links prev...tag', () => {
+    assert.equal(
+        compareUrl('DevinoSolutions/upup', 'v3.0.0', 'v3.1.0'),
+        'https://github.com/DevinoSolutions/upup/compare/v3.0.0...v3.1.0',
+    )
+})
+
+test('contributorLine prefers handle, pluralizes commits', () => {
+    assert.equal(
+        contributorLine({ handle: 'octocat', commits: 1 }),
+        '- @octocat — 1 commit',
+    )
+    assert.equal(
+        contributorLine({ name: 'Ada', commits: 3 }),
+        '- Ada — 3 commits',
+    )
+    assert.equal(contributorLine({ name: 'Ada' }), '- Ada')
+})
+
+test('buildReleaseNotes lists every package with a version-pinned npm link', () => {
+    const md = buildReleaseNotes({ version: '3.1.0', packages: PKGS })
+    assert.match(md, /## 📦 Packages/)
+    assert.match(md, /All 2 packages are published/)
+    for (const p of PKGS) {
+        assert.ok(
+            md.includes(`[\`${p.name}\`](${npmPackageUrl(p.name, p.version)})`),
+            `missing npm link for ${p.name}`,
+        )
+    }
+    // install + footer always present
+    assert.match(md, /## 📥 Install/)
+    assert.match(md, /npm i @upupjs\/react/)
+    assert.match(md, /MIT licensed/)
+    assert.ok(md.endsWith('\n'))
+})
+
+test('compare link appears only when a previousTag is supplied', () => {
+    const withPrev = buildReleaseNotes({
+        version: '3.1.0',
+        packages: PKGS,
+        previousTag: 'v3.0.0',
+    })
+    assert.match(withPrev, /Full changelog:/)
+    assert.match(withPrev, /compare\/v3\.0\.0\.\.\.v3\.1\.0/)
+
+    const noPrev = buildReleaseNotes({ version: '3.1.0', packages: PKGS })
+    assert.doesNotMatch(noPrev, /Full changelog:/)
+})
+
+test('highlights are prepended verbatim and contributors rendered', () => {
+    const md = buildReleaseNotes({
+        version: '3.1.0',
+        packages: PKGS,
+        highlights: '## Highlights\n\n- A brand new thing',
+        contributors: [{ handle: 'octocat', commits: 2 }],
+    })
+    assert.ok(md.startsWith('## Highlights\n\n- A brand new thing'))
+    assert.match(md, /## 👥 Contributors/)
+    assert.match(md, /- @octocat — 2 commits/)
+})
+
+test('throws on missing version or empty package set', () => {
+    assert.throws(() => buildReleaseNotes({ packages: PKGS }), /version/)
+    assert.throws(
+        () => buildReleaseNotes({ version: '3.1.0', packages: [] }),
+        /packages/,
+    )
+})


### PR DESCRIPTION
## What

Replaces the **9 per-package GitHub releases** with **one umbrella `v<version>` release** that feels like a proper release, built by a reusable generator.

### Added
- `scripts/lib/release-notes.mjs` — pure, tested builder (`scripts/lib/release-notes.test.mjs`, wired into `test:scripts`).
- `scripts/generate-release-notes.mjs` — CLI: gathers the publishable `@upupjs/*` set (fs), version, previous tag + contributors (git), emits the Markdown.

### Release notes now include
- 📦 every `@upupjs/*` package with a **version-pinned npm link**
- 📥 install commands · 👥 contributors (git shortlog over the range)
- 📝 GitHub's auto "What's changed" + a full-changelog **compare link**

### Config
- `.changeset/config.json`: enable **`@changesets/changelog-github`** (per-package `CHANGELOG.md` with PR/author links) and **`fixed`** all `@upupjs/*` so a release shares one version.
- `publish.yml`: `fetch-depth: 0` (history + tags), push package tags, build the umbrella release; **idempotent** (skips if the `v`-tag release already exists).

This is the same generator that produced the [v3.0.0 release](https://github.com/DevinoSolutions/upup/releases/tag/v3.0.0) notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)