### PR TITLE
ci: store workflow artifacts on self-hosted MinIO (DevinoSolutions/artifact)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,7 @@
 name: E2E
 
 permissions:
+    id-token: write
     contents: read
 
 on:
@@ -143,7 +144,7 @@ jobs:
             # nothing, which means the capture layer itself broke.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: e2e-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -152,7 +153,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: e2e-playwright-artifacts
                   path: |
@@ -293,7 +294,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: docs-e2e-playwright-artifacts
                   path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 permissions:
+    id-token: write
     contents: read
 on:
     pull_request:
@@ -76,7 +77,7 @@ jobs:
               run: pnpm run vocab:check
 
             - name: Archive code coverage results
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: code-coverage-report
                   path: coverage/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly
 
 permissions:
+    id-token: write
     contents: read
 
 # Deep suites too slow or too external for every PR: the full e2e gate plus
@@ -100,7 +101,7 @@ jobs:
             # future snapvisor.io baseline feed.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: nightly-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -109,7 +110,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: nightly-playwright-artifacts
                   path: |
@@ -381,7 +382,7 @@ jobs:
 
             - name: Upload Lighthouse reports
               if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: nightly-lighthouse-reports
                   path: apps/landing/.lighthouseci-reports/
@@ -455,7 +456,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure() && steps.creds.outputs.present == 'true'
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              uses: DevinoSolutions/artifact/upload@v1
               with:
                   name: landing-feedback-playwright-artifacts
                   path: |


### PR DESCRIPTION
Moves every `actions/upload-artifact` / `actions/download-artifact` step to
[`DevinoSolutions/artifact`](https://github.com/DevinoSolutions/artifact), a drop-in
replacement that stores artifacts on Devino's own MinIO (`storage.devino.ca`) instead
of GitHub's metered artifact storage.

**Why:** the org is on the free plan (500 MB artifact quota) with a $0 hard-stop Actions
budget, so once the quota is exceeded every artifact upload is rejected. Self-hosted
runners do not avoid this; the upstream action always writes to GitHub's blob store.

**What changed**
- `uses:` lines swapped to `DevinoSolutions/artifact/upload@v1` / `download@v1`; all inputs are compatible.
- Jobs that upload/download now request `id-token: write`, because the action authenticates to MinIO with the job's GitHub OIDC token (no secrets). Where a job had no `permissions` block, `permissions: write-all` is added, which equals the repo's current default token scopes plus `id-token`.
- `retention-days` is honoured via bucket lifecycle rules (rounded up to 1/3/5/7/14/30 days; anything above 30 keeps the 90-day default).

Artifacts are listed in each job's step summary as `s3://gh-artifacts/<owner>/<repo>/<run_id>/<name>.tgz` and can be fetched with `mc` or browsed at `minio-console.devino.ca`.
