### PR TITLE
fix: make Blob/BodyInit fixture types and the Angular TS pin survive a lockfile float (#351 unblock)

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -101,7 +101,7 @@
         "postcss": "^8.5.2",
         "postcss-cli": "^11.0.1",
         "rxjs": "^7.8.0",
-        "typescript": "^5.6.0",
+        "typescript": "~5.6.0",
         "vite": "^7",
         "vitest": "^4.1.2",
         "zone.js": "^0.14.0"

--- a/packages/core/tests/helpers/fixtures.ts
+++ b/packages/core/tests/helpers/fixtures.ts
@@ -19,8 +19,12 @@ import type {
 export const HEIC_SAMPLE_BASE64 =
     'AAAAHGZ0eXBoZWljAAAAAG1pZjFoZWljbWlhZgAAAVRtZXRhAAAAAAAAACFoZGxyAAAAAAAAAABwaWN0AAAAAAAAAAAAAAAAAAAAACJpbG9jAAAAAERAAAEAAQAAAAABeAABAAAAAAAAAB4AAAAjaWluZgAAAAAAAQAAABVpbmZlAgAAAAABAABodmMxAAAAAA5waXRtAAAAAAABAAAA1GlwcnAAAAC1aXBjbwAAAHhodmNDAQNwAAAAAAAAAAAAHvAA/P34+AAADwNgAAEAGEABDAH//wNwAAADAJAAAAMAAAMAHroCQGEAAQArQgEBA3AAAAMAkAAAAwAAAwAeoCCBBZbqSSmubgIaDAgAAAMAyAAAAwAIQGIAAQAHRAHBcrAiQAAAABNjb2xybmNseAABAA0ABoAAAAAUaXNwZQAAAAAAAABAAAAAQAAAAA5waXhpAAAAAAEIAAAAF2lwbWEAAAAAAAAAAQABBIECAwQAAAAmbWRhdAAAABooAa8E+EEyacv/S7/5H9i13//vHhpPRxg2/A=='
 
-function toBytes(buffer: Buffer): Uint8Array {
-    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+// Copies rather than views the Buffer: the (buffer, byteOffset, length) form
+// types as Uint8Array<ArrayBufferLike> under TypeScript >= 5.7, which BlobPart
+// rejects. The single-argument form yields Uint8Array<ArrayBuffer>. The return
+// type is left inferred so it stays correct on either side of that lib change.
+function toBytes(buffer: Buffer) {
+    return new Uint8Array(buffer)
 }
 
 export function buildHeicFile(name = 'sample.heic'): File {

--- a/packages/core/tests/helpers/node-canvas-shim.ts
+++ b/packages/core/tests/helpers/node-canvas-shim.ts
@@ -20,8 +20,12 @@ function toQualityInt(quality: number | undefined): number {
     return Math.max(0, Math.min(100, Math.round(q * 100)))
 }
 
-function toBytes(buffer: Buffer): Uint8Array {
-    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+// Copies rather than views the Buffer: the (buffer, byteOffset, length) form
+// types as Uint8Array<ArrayBufferLike> under TypeScript >= 5.7, which BlobPart
+// rejects. The single-argument form yields Uint8Array<ArrayBuffer>. The return
+// type is left inferred so it stays correct on either side of that lib change.
+function toBytes(buffer: Buffer) {
+    return new Uint8Array(buffer)
 }
 
 class NodeOffscreenCanvas {

--- a/packages/storybook-config/src/fixtures/base64.ts
+++ b/packages/storybook-config/src/fixtures/base64.ts
@@ -1,9 +1,13 @@
 // src/fixtures/base64.ts
 // Tiny base64 → bytes decoder shared by the binary fixtures. Uses the global
 // atob (present in browsers and Node ≥18), so the fixtures stay bundler-agnostic.
-export function base64ToBytes(b64: string): Uint8Array {
-  const bin = atob(b64)
-  const bytes = new Uint8Array(bin.length)
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
-  return bytes
+// The return type is left inferred (Uint8Array<ArrayBuffer> under TypeScript
+// >= 5.7, plain Uint8Array before it). Annotating it as bare `Uint8Array`
+// widens to Uint8Array<ArrayBufferLike> on the newer lib, which BlobPart
+// rejects at the `new File([...])` call sites.
+export function base64ToBytes(b64: string) {
+    const bin = atob(b64)
+    const bytes = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+    return bytes
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,7 +878,7 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
       typescript:
-        specifier: ^5.6.0
+        specifier: ~5.6.0
         version: 5.6.3
       vite:
         specifier: ^7


### PR DESCRIPTION
Unblocks dependabot #351 (`chore(deps): bump nanoid`), whose lockfile regen floats `typescript` from 5.6.3 to 5.9.3 within the ranges already declared in `package.json`. TypeScript >= 5.7 makes `Uint8Array` generic, which breaks fixtures that feed bytes into `new File([...])` / `new Blob([...])`. This PR makes those sites green under **both** the committed lockfile and the floated one, so #351 goes green on rebase without carrying source fixes of its own.

Does **not** touch the lockfile's dependency versions — that stays #351's job. The single lockfile line here is a `specifier:` correction paired with the `packages/angular` range narrowing (resolved version unchanged at 5.6.3); `pnpm install --frozen-lockfile` passes.

## Reproduction

`pnpm update -r typescript "@types/node"` — floats within existing ranges, landing on the same resolutions as #351's lockfile (verified against `refs/pull/351/head`: its `packages/angular` importer pins `typescript@5.9.3`). `@types/node` itself did not move (22.20.1 was already latest-in-range); the float that matters is TypeScript's lib.

## Residues found and fixed

**1. `packages/core` test helpers — RED**

```
tests/helpers/fixtures.ts(28,22): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
tests/helpers/fixtures.ts(64,22): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
tests/helpers/node-canvas-shim.ts(72,26): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
```

Both files had `toBytes(buffer: Buffer): Uint8Array` returning `new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)` — the three-argument view form, which types as `Uint8Array<ArrayBufferLike>`. Now `new Uint8Array(buffer)`: a copy, typed `Uint8Array<ArrayBuffer>`. Return annotation dropped so inference stays right on either lib. Copy-vs-view is a safe change here (and arguably safer — Node pools Buffer memory, so a view can alias).

**2. `packages/storybook-config` fixtures — RED**

```
src/fixtures/heicSample.ts(10,20): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
src/fixtures/pngSample.ts(10,20): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
```

Cascaded into `storybook-react`, `storybook-vue`, `storybook-vanilla` and `storybook-preact`, which typecheck that source directly. Root cause is one choke point: `base64ToBytes` annotated its return as bare `Uint8Array`, widening the correctly-narrow `new Uint8Array(length)` result. Annotation dropped; the two fixture files are untouched.

**3. `apps/next-example` TS2305 — already fixed on dev, no action**

#351's CI showed `lib/upup-config.ts(2,15): error TS2305: Module '"@upupjs/next/server"' has no exported member 'UpupServerConfig'`. That was master-baseline staleness, not a types float: `packages/next/src/server.ts:15` now re-exports `UpupServerConfig` (F-852). Confirmed green at dev HEAD under the float — `@upupjs/next` and `apps/next-example` both pass.

**4. `@upupjs/angular` build — RED (new; not in the original three)**

```
@upupjs/angular build: ng-packagr, Ivy partial compilation
  "The Angular Compiler requires TypeScript >=5.5.0 and <5.9.0 but 5.9.3 was found instead."
```

cascading into:

```
apps/storybook-angular src/stories/Uploader.stories.ts(5,39): error TS2307: Cannot find module '@upupjs/angular' or its corresponding type declarations.
  (same at Uploader.stories.ts:6, WorkerHeic.stories.ts:5 and :6)
```

`packages/angular` declared `"typescript": "^5.6.0"`, which floats past Angular 19's ceiling. Narrowed to `"~5.6.0"`, matching what `apps/storybook-angular` already pins. Angular 19's real ceiling is `<5.9.0`, so this can widen when the Angular major moves.

**This is the one change that is arguably a dependency decision rather than type work, so it is isolated in its own commit (`d67d21d1`) and can be dropped independently.** Without it, though, #351 still fails Build, Typecheck and the storybook jobs.

## Verification

Under the **floated** resolutions (`packages/angular` held at TypeScript 5.6.3 by the new pin; `core` and `storybook-config` at 5.9.3):

- `pnpm run typecheck` — **31/31, exit 0**, including `@upupjs/angular#build` and `@upupjs/storybook-angular#typecheck`

Back on the **committed** lockfile (`pnpm install --frozen-lockfile`, exit 0):

- `pnpm run typecheck` — 31/31, exit 0
- `pnpm run test` — 28/28, exit 0
- `pnpm run build` — 14/14, exit 0
- `pnpm run lint` — 20/20, exit 0
- `pnpm run prettier-check` — exit 0

`apps/landing` and `apps/mastra` failed once in a full parallel `test` run and passed both in isolation and on re-run — the documented load-sensitive flake, with no import path to any changed file.

Per CLAUDE.md's CI-blind-formatting rule, `prettier --check` was run explicitly on all touched paths (`packages/core/tests/**` and `packages/storybook-config/src/**` are both outside the `prettier-check` glob). It caught `base64.ts`, hence the 4-space reformat of that function body to the root config in commit `fa6c584f`.

No changeset: test-fixture and type-annotation changes plus a devDependency range. Nothing in any published runtime surface or public API.

e2e and `smoke:packages` were skipped as out of scope for type-annotation work; CI covers them.
