### PR TITLE
fix: keep the animated-image test fixtures BlobPart-compatible under TypeScript >= 5.7

### DIFF
--- a/packages/core/tests/helpers/animated-image-fixtures.ts
+++ b/packages/core/tests/helpers/animated-image-fixtures.ts
@@ -7,7 +7,10 @@
 
 export type BytePart = number[] | string | Uint8Array
 
-export function concatBytes(...parts: BytePart[]): Uint8Array {
+// Return annotations are deliberately inferred: an explicit `: Uint8Array`
+// means `Uint8Array<ArrayBufferLike>` on TypeScript >= 5.7, which is not
+// assignable to `BlobPart` (same float #368 fixed in the sibling helpers).
+export function concatBytes(...parts: BytePart[]) {
     const out: number[] = []
     for (const part of parts) {
         if (typeof part === 'string') {
@@ -24,7 +27,7 @@ export function concatBytes(...parts: BytePart[]): Uint8Array {
 // field's GCT flag and appends a two-entry (red/blue) table.
 export function gifHeader({
     globalColourTable = true,
-}: { globalColourTable?: boolean } = {}): Uint8Array {
+}: { globalColourTable?: boolean } = {}) {
     if (!globalColourTable) {
         return concatBytes('GIF89a', [0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00])
     }
@@ -74,11 +77,11 @@ export const GIF_GRAPHIC_CONTROL = [
 
 export const GIF_TRAILER = [0x3b]
 
-export function stillGifBytes(): Uint8Array {
+export function stillGifBytes() {
     return concatBytes(gifHeader(), gifFrame(0), GIF_TRAILER)
 }
 
-export function animatedGifBytes(): Uint8Array {
+export function animatedGifBytes() {
     return concatBytes(
         gifHeader(),
         GIF_NETSCAPE_LOOP,
@@ -94,7 +97,7 @@ export function animatedGifBytes(): Uint8Array {
 export const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 
 /** A length-prefixed, CRC-suffixed PNG chunk with zero-filled data. */
-export function pngChunk(type: string, dataLength = 0): Uint8Array {
+export function pngChunk(type: string, dataLength = 0) {
     return concatBytes(
         [
             (dataLength >>> 24) & 0xff,
@@ -108,7 +111,7 @@ export function pngChunk(type: string, dataLength = 0): Uint8Array {
     )
 }
 
-export function stillPngBytes(): Uint8Array {
+export function stillPngBytes() {
     return concatBytes(
         PNG_SIGNATURE,
         pngChunk('IHDR', 13),
@@ -117,7 +120,7 @@ export function stillPngBytes(): Uint8Array {
     )
 }
 
-export function apngBytes(): Uint8Array {
+export function apngBytes() {
     return concatBytes(
         PNG_SIGNATURE,
         pngChunk('IHDR', 13),
@@ -129,7 +132,7 @@ export function apngBytes(): Uint8Array {
 
 // ── WebP ────────────────────────────────────────────────────────
 /** A RIFF chunk: FourCC, little-endian size, payload padded to an even length. */
-export function riffChunk(fourCC: string, data: number[]): Uint8Array {
+export function riffChunk(fourCC: string, data: number[]) {
     const size = data.length
     return concatBytes(
         fourCC,
@@ -144,12 +147,12 @@ export function riffChunk(fourCC: string, data: number[]): Uint8Array {
     )
 }
 
-export function webpContainer(...chunks: BytePart[]): Uint8Array {
+export function webpContainer(...chunks: BytePart[]) {
     return concatBytes('RIFF', [0x00, 0x00, 0x00, 0x00], 'WEBP', ...chunks)
 }
 
 /** VP8X payload: flags byte then a 9-byte canvas description. */
-export function vp8xChunk(flags: number): Uint8Array {
+export function vp8xChunk(flags: number) {
     return riffChunk('VP8X', [
         flags,
         0x00,
@@ -167,11 +170,11 @@ export function vp8xChunk(flags: number): Uint8Array {
 const VP8X_ANIMATION_FLAG = 0x02
 export const VP8X_ALPHA_FLAG = 0x10
 
-export function stillWebpBytes(): Uint8Array {
+export function stillWebpBytes() {
     return webpContainer(riffChunk('VP8 ', [0x00, 0x00, 0x00, 0x00]))
 }
 
-export function animatedWebpBytes(): Uint8Array {
+export function animatedWebpBytes() {
     return webpContainer(
         vp8xChunk(VP8X_ANIMATION_FLAG),
         riffChunk('ANIM', [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),

--- a/packages/core/tests/steps/image-processing.test.ts
+++ b/packages/core/tests/steps/image-processing.test.ts
@@ -210,7 +210,10 @@ describe('browser image processing steps', () => {
 // here precisely so a re-encode WOULD happen if the guard were missing.
 // ─────────────────────────────────────────────
 describe('animated images skip the canvas re-encode steps', () => {
-    const animated: [string, string, Uint8Array][] = [
+    // BlobPart, not Uint8Array: a bare Uint8Array annotation widens to
+    // Uint8Array<ArrayBufferLike> on TypeScript >= 5.7 and stops being a
+    // BlobPart; these bytes only ever feed makeUploadFile.
+    const animated: [string, string, BlobPart][] = [
         ['an animated GIF', 'loop.gif', animatedGifBytes()],
         ['an animated WebP', 'loop.webp', animatedWebpBytes()],
         ['an APNG', 'loop.png', apngBytes()],


### PR DESCRIPTION
Unblocks the three npm dependabot PRs (#351, #355, #356), whose rebased lockfiles float `typescript` 5.6.3 → 5.9.3 and all fail Typecheck the same way.

## The defect

PR #365's animated-image test fixtures postdate #368's `Uint8Array`-generics sweep (which was verified at dev `9b381b8b`, before #365 merged) and reintroduce the same pattern: explicit `: Uint8Array` return annotations, which on TypeScript ≥ 5.7 mean `Uint8Array<ArrayBufferLike>` — not assignable to `BlobPart`.

RED, from the live Typecheck failure on #355's rebase (7 errors, all `@upupjs/core`):

```
tests/steps/animated-image-detection.test.ts(26,22): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
tests/steps/image-processing.test.ts(171,13): error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BlobPart | undefined'.
(+ 228, 242, 270, 289, and the ELIFECYCLE exit 2)
```

## The fix (same convention as #368)

- `tests/helpers/animated-image-fixtures.ts`: dropped the 12 explicit `: Uint8Array` return annotations — inference from `new Uint8Array(number[])` yields the narrow `Uint8Array<ArrayBuffer>` on TS ≥ 5.7 and plain `Uint8Array` on ≤ 5.6.
- `tests/steps/image-processing.test.ts`: the `animated` table annotation `[string, string, Uint8Array][]` → `[string, string, BlobPart][]` (valid on both TS versions; the bytes only ever feed `makeUploadFile`, whose parameter is `BlobPart`). Note `Uint8Array<ArrayBuffer>` syntax was NOT an option — it's a parse error on TS ≤ 5.6.

Test-only; no runtime or published-surface change, so no changeset.

## Verification (raw exit codes)

- **GREEN under the float**: `pnpm update -r typescript` (lands typescript@5.9.3, same resolution as the dependabot lockfiles; angular held at 5.6.3 by #368's `~5.6.0` pin) → `tsc --version` prints 5.9.3 → `@upupjs/core` typecheck (base + `tsconfig.test.json`) exit 0.
- **GREEN under the committed lockfile**: scaffolding reverted, `pnpm install --frozen-lockfile` exit 0, `tsc --version` prints 5.6.3, core typecheck exit 0.
- Pre-commit hook ran the core suite (337 passed / 41 skipped); pre-push ran full typecheck + lint + knip.
- Touched files are outside `packages/*/src` (CI-blind for formatting): explicit `prettier --check` on both — clean.
