### PR TITLE
fix(e2e-test): declare the @upupjs/server workspace dependency it imports

### DIFF
--- a/apps/e2e-test/package.json
+++ b/apps/e2e-test/package.json
@@ -25,6 +25,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@upupjs/server": "workspace:*",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "~5.3.0",
         "vite": "^8.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.5(@types/react@19.2.18)
+      '@upupjs/server':
+        specifier: workspace:*
+        version: link:../../packages/server
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.7.0(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.13)(yaml@2.9.0))
@@ -19143,7 +19146,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.11)(jsdom@22.1.0)(msw@2.15.0(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.2(@types/node@20.19.43)(esbuild@0.28.2)(jiti@1.21.7)(less@4.6.4)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.11)(jsdom@22.1.0)(msw@2.15.0(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.2(@types/node@20.19.43)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
Unblocks dependabot #356 (hono 4.13.2), whose Typecheck failure exposed a latent phantom-dependency race rather than a hono type break.

## The defect

`apps/e2e-test/drive-sandbox/server-transfer.spec.ts` imports `@upupjs/server` and `@upupjs/server/node-bridge`, but `@upupjs/e2e-test` never declared the dependency. Turbo therefore had no `e2e-test → server` edge, so `typecheck`'s `^build` did not cover `@upupjs/server` — `tsc` could run while (or before) server's `dist/` was being emitted.

The race only loses when server's build cache misses in the Typecheck job. On #356's rebase (run 33669841748) the hono bump invalidated server's turbo hash, the real build ran concurrently, and e2e-test's tsc read a half-built dist:

```
drive-sandbox/server-transfer.spec.ts(52,8): error TS7016: Could not find a declaration file for module '@upupjs/server'. '.../packages/server/dist/index.js' implicitly has an 'any' type.
drive-sandbox/server-transfer.spec.ts(53,48): error TS7016: Could not find a declaration file for module '@upupjs/server/node-bridge'.
```

The job log timestamps show `@upupjs/server:build` starting at 18:57:44 and still emitting at 18:58:03 while the e2e-test errors landed at 18:57:56 — concurrent execution, i.e. a missing graph edge, not a type regression. Green runs on master/#355 were cache-hit luck.

## The fix

Declare `"@upupjs/server": "workspace:*"` in `@upupjs/e2e-test`'s devDependencies (+ the lockfile entry pnpm derives). Structural acceptance: `turbo run typecheck --filter=@upupjs/e2e-test --dry-run` now lists `@upupjs/server#build` under Dependencies.

knip ignores `apps/**` (its enforced scope is packages/* only), so the new devDep introduces no gate noise. Private app, no runtime or published-surface change → no changeset.

## Verification (raw exit codes)

- `turbo run typecheck --filter=@upupjs/e2e-test --dry-run` → `@upupjs/e2e-test#typecheck` Dependencies now include `@upupjs/server#build` + `@upupjs/server#typecheck`.
- `pnpm --filter @upupjs/e2e-test run typecheck` exit 0.
- Pre-commit hook ran the core/react/server unit suites; pre-push ran full typecheck + lint + knip.
