### PR TITLE
fix(ci): pin changesets/action back to v1 to match Changesets CLI v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,39 @@
 version: 2
 updates:
-  # Published surface + workspace deps. `npm` ecosystem reads pnpm-lock.yaml (v9).
-  - package-ecosystem: 'npm'
-    directories:
-      - '/'
-      - '/packages/*'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-    open-pull-requests-limit: 5
-    groups:
-      production-dependencies:      # prioritise the shipped prod deps, one PR
-        applies-to: version-updates
-        dependency-type: 'production'
-        update-types: ['minor', 'patch']
-      development-dependencies:
-        applies-to: version-updates
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-    ignore:
-      # Majors are DEFERRED (F-189: Angular 19->22, Storybook 9->10, Tailwind
-      # 3->4, TS 5->6, Vite/Rollup/ESLint/jsdom). See audit/deferred-roadmap.md.
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    groups:
-      github-actions:
-        patterns: ['*']
+    # Published surface + workspace deps. `npm` ecosystem reads pnpm-lock.yaml (v9).
+    - package-ecosystem: 'npm'
+      directories:
+          - '/'
+          - '/packages/*'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      open-pull-requests-limit: 5
+      groups:
+          production-dependencies: # prioritise the shipped prod deps, one PR
+              applies-to: version-updates
+              dependency-type: 'production'
+              update-types: ['minor', 'patch']
+          development-dependencies:
+              applies-to: version-updates
+              dependency-type: 'development'
+              update-types: ['minor', 'patch']
+      ignore:
+          # Majors are DEFERRED (F-189: Angular 19->22, Storybook 9->10, Tailwind
+          # 3->4, TS 5->6, Vite/Rollup/ESLint/jsdom). See audit/deferred-roadmap.md.
+          - dependency-name: '*'
+            update-types: ['version-update:semver-major']
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      groups:
+          github-actions:
+              patterns: ['*']
+      ignore:
+          # changesets/action's major track is coupled to the Changesets CLI major:
+          # v2.x refuses to run against CLI v2 (this repo's @changesets/cli). A bump
+          # here reds the release pipeline until the CLI is upgraded too, so the two
+          # move in one deliberate change, never as a grouped action bump.
+          - dependency-name: 'changesets/action'
+            update-types: ['version-update:semver-major']

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,10 @@ jobs:
             - name: Create Release Pull Request
               if: github.ref == 'refs/heads/master'
               id: changesets
-              uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+              # Action v1 is the track that supports Changesets CLI v2 (this repo's
+              # @changesets/cli). v2.x hard-errors unless the CLI is v3, so this pin
+              # only moves together with a CLI major upgrade.
+              uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
               with:
                   createGithubReleases: false
               env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,6 +641,12 @@ DrivePlugin`. All three popup providers now persist a token-expiry key and refre
   need publishing) a pre-publish gate — typecheck, unit suites, build, size,
   `smoke:packages` — before `pnpm run release` (`changeset publish`, which
   skips versions already on npm); on dev: `test-release` dry-run.
+  **`changesets/action`'s major is coupled to the Changesets CLI major** — the
+  v2 action hard-errors ("designed to work with Changesets CLI v3") against this
+  repo's CLI v2, so a grouped dependabot action bump silently reds the release
+  pipeline (it did, 2026-09-02, and the failure is invisible until a push to
+  master). The pin is v1.9.0 and dependabot now ignores its majors; move the
+  action and `@changesets/cli` together or not at all.
 - **Branch protection must require BOTH rollup checks** (F-780): `Status Check`
   (main.yml) AND `E2E Status Check` (e2e.yml). main.yml's rollup aggregates only
   its own jobs; e2e.yml's rollup aggregates E2E + Smoke-Packages. Requiring only


### PR DESCRIPTION
The `Publish` workflow has failed on every push to master since 5c02fbe7, at the release-PR step:

```
Error: This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.
```

The grouped github-actions dependabot bump moved `changesets/action` 1.9.0 → 2.1.1 (a major). The v2 action refuses to run against a v2 Changesets CLI, and this repo is on `@changesets/cli ^2.30.0`. The same bump also explains the pre-existing `Unexpected input(s) 'createGithubReleases'` warning — v2 renamed the inputs to kebab-case.

Nothing about the failure is visible on a PR: `publish.yml` only runs on push to master, so it went unnoticed through two merges (#373 and #374).

## Changes

- **`publish.yml`** — pin back to `changesets/action@a45c4d59 # v1.9.0`, with a comment recording that this pin only moves together with a `@changesets/cli` major.
- **`dependabot.yml`** — the `github-actions` ecosystem had **no major-version guard**, unlike `npm` (which ignores majors wholesale per F-189). That is how a breaking action major arrived in a routine grouped bump. `changesets/action` majors are now ignored.
- **`CLAUDE.md`** — records the action↔CLI major coupling and that the failure is invisible until a push to master.

The `actions/checkout` and `actions/setup-node` v7 bumps from the same commit are left alone — they are green across main.yml, e2e.yml, and CodeQL.

## Verification

`dependabot.yml` was already unformatted before this change (the documented CI blind spot outside `packages/*/src` — prettier there is enforced only by the pre-commit hook), so `prettier --write` was applied; that accounts for the indentation-only half of its diff.

Core's suite failed once inside the pre-commit hook (1 of 1729) and passed isolated at 143/143 files, 1729/1729 tests — a load flake per the documented protocol, not related to this change, which touches only CI config and docs.

The real proof is post-merge: the next push to master must run the release-PR step without the CLI-version error.
