### PR TITLE
chore: sync dev with master (CI artifact storage)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,7 +144,7 @@ jobs:
             # nothing, which means the capture layer itself broke.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: e2e-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -153,7 +153,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: e2e-playwright-artifacts
                   path: |
@@ -294,7 +294,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: docs-e2e-playwright-artifacts
                   path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
               run: pnpm run vocab:check
 
             - name: Archive code coverage results
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: code-coverage-report
                   path: coverage/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
             # future snapvisor.io baseline feed.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: nightly-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -110,7 +110,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: nightly-playwright-artifacts
                   path: |
@@ -382,7 +382,7 @@ jobs:
 
             - name: Upload Lighthouse reports
               if: always()
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: nightly-lighthouse-reports
                   path: apps/landing/.lighthouseci-reports/
@@ -456,7 +456,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure() && steps.creds.outputs.present == 'true'
-              uses: DevinoSolutions/artifact/upload@v1
+              uses: actions/upload-artifact@v4
               with:
                   name: landing-feedback-playwright-artifacts
                   path: |


### PR DESCRIPTION
## Summary
- Brings dev level with master after 8966013d (`ci: public repo uses GitHub's free artifact storage`) landed directly on master.
- No code changes beyond that one CI commit; keeps master = dev as the integration invariant.

## Test Plan
- [ ] Status Check + E2E Status Check rollups green on this PR