### PR TITLE
fix(core): #367 follow-ups — proxy error pages, message-at-construction, prefix animation sniff

### DIFF
--- a/.changeset/prefix-sniff-clean-presign.md
+++ b/.changeset/prefix-sniff-clean-presign.md
@@ -1,0 +1,30 @@
+---
+'@useupup/core': patch
+---
+
+Presign failures no longer surface a reverse proxy's HTML error page, and the
+animated-image guard stops reading whole files.
+
+`TokenEndpointCredentials.getPresignedUrl` reads a failed presign body so the
+endpoint's own sentence reaches `onError`, but `parseErrorBody`'s text fallback
+also caught the error pages nginx and Cloudflare write for a 502 or 413 — so a
+handler that used to get `Presign request failed: 502 Bad Gateway` got 200
+characters of `<html>` instead. A markup body carrying no error code is now
+treated as nothing to surface and the status-line wording is kept. An S3-style
+`<Error><Code>` body is unaffected: it parses to a real code and still comes
+through. The error is also built with its final message rather than having
+`message` reassigned afterwards, so the body is parsed once and the error never
+carries wording it does not keep. `uploadErrorFromResponse` gained two optional
+arguments for this — `fallbackMessage` (wording to use when the body carries
+nothing) and `ignoreErrorPageBody` (opt into the markup guard); callers that
+pass neither behave exactly as before.
+
+`isAnimatedImage` — the guard that keeps `imageCompression` and `stripExifData`
+from flattening animated GIF/WebP/APNG — used to call `arrayBuffer()` on the
+whole file, a read the main-thread path never made before that guard existed,
+so a still 40 MB photo was materialized in full just to learn it was still. It
+now sniffs the first 64 KiB, which is where every one of these formats declares
+animation (APNG's `acTL` before the first `IDAT`, WebP's `VP8X`/`ANIM` at the
+top of the container, a looping GIF's `NETSCAPE2.0` extension in the header).
+Only a GIF that has announced nothing by then is read in full, because its
+second Image Descriptor can sit anywhere in the stream. Verdicts are unchanged.

--- a/apps/landing/content/docs/api-reference/error-codes.mdx
+++ b/apps/landing/content/docs/api-reference/error-codes.mdx
@@ -247,9 +247,10 @@ uploads.
 
 The presign call a custom `uploadEndpoint` makes routes through it too, so the
 sentence your endpoint writes into a non-2xx body is what `onError` receives —
-you do not have to recover it from an HTTP status. When the body is empty or
-unreadable the message stays `Presign request failed: <status> <statusText>`,
-the wording that path has always thrown.
+you do not have to recover it from an HTTP status. When the body is empty,
+unreadable, or an HTML error page a reverse proxy wrote with no error code of
+its own, the message stays `Presign request failed: <status> <statusText>`, the
+wording that path has always thrown.
 
 ```typescript
 import { uploadErrorFromResponse } from '@useupup/core'

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -401,4 +401,52 @@ describe('uploadErrorFromResponse', () => {
         expect(err.message).toContain('500')
         expect(err.status).toBe(500)
     })
+
+    it("prefers the caller's fallback message over the status line", () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '',
+            kind: 'network',
+            fallbackMessage: 'Presign request failed: 502 Bad Gateway',
+        })
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+    })
+
+    it('discards a proxy error page when the caller opts in', () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+            kind: 'network',
+            ignoreErrorPageBody: true,
+            fallbackMessage: 'Presign request failed: 502 Bad Gateway',
+        })
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+    })
+
+    it('keeps a code-carrying XML body even with the error-page guard on', () => {
+        const err = uploadErrorFromResponse({
+            status: 403,
+            statusText: 'Forbidden',
+            body: '<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>',
+            kind: 'network',
+            ignoreErrorPageBody: true,
+            fallbackMessage: 'Presign request failed: 403 Forbidden',
+        })
+        expect(err.message).toBe('Access Denied')
+        expect(err.code).toBe('AccessDenied')
+    })
+
+    it('leaves a markup body alone for callers that do not opt in', () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+            kind: 'network',
+        })
+        expect(err.message).toBe(
+            '<html><body><h1>502 Bad Gateway</h1></body></html>',
+        )
+    })
 })

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -193,6 +193,24 @@ export interface UploadErrorFromResponseArgs {
     operation?: UpupStorageError['operation']
     /** Provider label for storage/auth errors (e.g. 'S3', 'google-drive'). Defaults to 'server'. */
     provider?: string
+    /**
+     * Message to use when the body carries nothing worth surfacing. Defaults
+     * to `${status} ${statusText}`; a caller passes its own to keep wording it
+     * has always thrown.
+     */
+    fallbackMessage?: string
+    /**
+     * Treat a markup body carrying no error code as nothing worth surfacing.
+     * A reverse proxy or CDN answers 502/413 with an HTML error page, and the
+     * text fallback would otherwise put 200 characters of it in `message`. An
+     * S3-style `<Error><Code>` body is unaffected — it parses to a real code.
+     */
+    ignoreErrorPageBody?: boolean
+}
+
+/** An HTML/XML body, told from the host's own copy by its opening tag. */
+function isMarkupBody(body: string | undefined): boolean {
+    return body !== undefined && body.trimStart().startsWith('<')
 }
 
 /**
@@ -205,9 +223,24 @@ export interface UploadErrorFromResponseArgs {
 export function uploadErrorFromResponse(
     args: UploadErrorFromResponseArgs,
 ): UpupError {
-    const { status, statusText, body, kind, operation, provider } = args
+    const {
+        status,
+        statusText,
+        body,
+        kind,
+        operation,
+        provider,
+        fallbackMessage,
+        ignoreErrorPageBody,
+    } = args
     const parsed = parseErrorBody(body)
-    const message = parsed.message || `${status} ${statusText}`.trim()
+    const surfaced =
+        ignoreErrorPageBody && !parsed.code && isMarkupBody(body)
+            ? ''
+            : parsed.message
+    const message = surfaced.trim()
+        ? surfaced
+        : (fallbackMessage ?? `${status} ${statusText}`.trim())
 
     let err: UpupError
     if (kind === 'auth') {

--- a/packages/core/src/steps/animated-image.ts
+++ b/packages/core/src/steps/animated-image.ts
@@ -9,10 +9,9 @@
  * instead.
  *
  * Detection is byte-level rather than `ImageDecoder`-based so it behaves the
- * same in every browser and is deterministic under test. Reading the whole
- * blob is cheaper than what the step does next either way — the worker path
- * already calls `file.arrayBuffer()`, and the main-thread path hands the file
- * to `createImageBitmap`, which decodes it to raw RGBA.
+ * same in every browser and is deterministic under test. It reads a prefix
+ * rather than the file: a still photo is the common case, and the main-thread
+ * path never materialised the bytes at all before this guard existed.
  */
 
 function ascii(bytes: Uint8Array, start: number, length: number): string {
@@ -180,14 +179,31 @@ function baseMimeType(type: string): string {
 }
 
 /**
+ * How much of the file the sniff reads before deciding. Every format declares
+ * animation near the front — APNG's `acTL` precedes the first `IDAT`, WebP's
+ * `VP8X`/`ANIM` open the RIFF container, and a looping GIF carries its
+ * NETSCAPE2.0 extension in the header — so 64 KiB answers all of them.
+ */
+const SNIFF_PREFIX_BYTES = 64 * 1024
+
+/**
  * True when the blob is an animated image in one of the three formats a canvas
  * re-encode would flatten. Anything else — including formats with no animated
  * variant — is false, so callers process it as before.
  */
 export async function isAnimatedImage(file: Blob): Promise<boolean> {
-    const sniff = SNIFFERS[baseMimeType(file.type)]
+    const type = baseMimeType(file.type)
+    const sniff = SNIFFERS[type]
     if (!sniff) return false
     try {
+        const prefix = new Uint8Array(
+            await file.slice(0, SNIFF_PREFIX_BYTES).arrayBuffer(),
+        )
+        if (sniff(prefix)) return true
+        // A GIF that does not announce itself in the header is only settled by
+        // the multi-descriptor walk, and the second descriptor can sit anywhere
+        // in the stream. No other format needs the rest of the bytes.
+        if (type !== 'image/gif' || file.size <= prefix.length) return false
         return sniff(new Uint8Array(await file.arrayBuffer()))
     } catch {
         // upup-catch: unreadable blob — let the step's own decode surface it

--- a/packages/core/src/strategies/token-endpoint.ts
+++ b/packages/core/src/strategies/token-endpoint.ts
@@ -21,6 +21,17 @@ async function readErrorBody(response: Response): Promise<string | undefined> {
     }
 }
 
+/**
+ * True when the body is markup rather than the endpoint's own copy. A reverse
+ * proxy or CDN answers 502/413 with an HTML error page, and `parseErrorBody`'s
+ * text fallback would otherwise surface 200 characters of it as the message.
+ * Callers pair this with "and the parse found no code", so an S3-style
+ * `<Error><Code>…` body — markup that does carry a code — still gets through.
+ */
+function looksLikeErrorPage(body: string | undefined): boolean {
+    return body !== undefined && body.trimStart().startsWith('<')
+}
+
 export class TokenEndpointCredentials implements CredentialStrategy {
     private url: string
     private headers: Record<string, string>
@@ -58,7 +69,11 @@ export class TokenEndpointCredentials implements CredentialStrategy {
                 ...(body !== undefined ? { body } : {}),
                 kind: 'network',
             })
-            if (!parseErrorBody(body).message.trim()) {
+            const parsed = parseErrorBody(body)
+            if (
+                !parsed.message.trim() ||
+                (!parsed.code && looksLikeErrorPage(body))
+            ) {
                 // Nothing usable in the body — keep the exact wording this
                 // strategy has always thrown, so a consumer matching on it
                 // sees no change.

--- a/packages/core/src/strategies/token-endpoint.ts
+++ b/packages/core/src/strategies/token-endpoint.ts
@@ -1,5 +1,4 @@
 import {
-    parseErrorBody,
     uploadErrorFromResponse,
     type CredentialStrategy,
     type FileMetadata,
@@ -19,17 +18,6 @@ async function readErrorBody(response: Response): Promise<string | undefined> {
         // upup-catch: body unreadable — fall back to the status-only message
         return undefined
     }
-}
-
-/**
- * True when the body is markup rather than the endpoint's own copy. A reverse
- * proxy or CDN answers 502/413 with an HTML error page, and `parseErrorBody`'s
- * text fallback would otherwise surface 200 characters of it as the message.
- * Callers pair this with "and the parse found no code", so an S3-style
- * `<Error><Code>…` body — markup that does carry a code — still gets through.
- */
-function looksLikeErrorPage(body: string | undefined): boolean {
-    return body !== undefined && body.trimStart().startsWith('<')
 }
 
 export class TokenEndpointCredentials implements CredentialStrategy {
@@ -63,22 +51,20 @@ export class TokenEndpointCredentials implements CredentialStrategy {
             // left consumers matching HTTP statuses out of upup's own message
             // text to recover what their server had already said.
             const body = await readErrorBody(response)
+            // Bound to a const so the error is thrown as constructed — the
+            // taxonomy lint reads a thrown call expression as a literal.
             const error = uploadErrorFromResponse({
                 status: response.status,
                 statusText: response.statusText,
                 ...(body !== undefined ? { body } : {}),
                 kind: 'network',
-            })
-            const parsed = parseErrorBody(body)
-            if (
-                !parsed.message.trim() ||
-                (!parsed.code && looksLikeErrorPage(body))
-            ) {
-                // Nothing usable in the body — keep the exact wording this
+                // An empty body, or an error page a reverse proxy wrote,
+                // carries nothing to surface: keep the exact wording this
                 // strategy has always thrown, so a consumer matching on it
                 // sees no change.
-                error.message = `Presign request failed: ${response.status} ${response.statusText}`
-            }
+                ignoreErrorPageBody: true,
+                fallbackMessage: `Presign request failed: ${response.status} ${response.statusText}`,
+            })
             throw error
         }
 

--- a/packages/core/tests/helpers/animated-image-fixtures.ts
+++ b/packages/core/tests/helpers/animated-image-fixtures.ts
@@ -70,6 +70,24 @@ export const GIF_NETSCAPE_LOOP = concatBytes(
     [0x03, 0x01, 0x00, 0x00, 0x00],
 )
 
+/**
+ * A Comment Extension carrying `length` bytes of filler, in the 255-byte
+ * sub-blocks the format requires. Lets a fixture push a later frame past a
+ * chosen offset without inventing an illegal container.
+ */
+export function gifComment(length: number): number[] {
+    const bytes = [0x21, 0xfe]
+    let left = length
+    while (left > 0) {
+        const size = Math.min(255, left)
+        bytes.push(size)
+        for (let i = 0; i < size; i += 1) bytes.push(0x20)
+        left -= size
+    }
+    bytes.push(0x00) // sub-block terminator
+    return bytes
+}
+
 /** Graphic Control Extension — legal on a single-frame GIF too. */
 export const GIF_GRAPHIC_CONTROL = [
     0x21, 0xf9, 0x04, 0x00, 0x0a, 0x00, 0x00, 0x00,

--- a/packages/core/tests/steps/animated-image-detection.test.ts
+++ b/packages/core/tests/steps/animated-image-detection.test.ts
@@ -4,6 +4,7 @@ import {
     concatBytes,
     gifHeader,
     gifFrame,
+    gifComment,
     riffChunk,
     pngChunk,
     vp8xChunk,
@@ -26,10 +27,56 @@ function image(type: string, ...parts: BytePart[]): Blob {
     return new Blob([concatBytes(...parts)], { type })
 }
 
-/** A blob stand-in whose `type` and read behaviour are fully controlled. */
-function fakeBlob(type: string, read: () => Promise<ArrayBuffer>): Blob {
-    return { type, arrayBuffer: read } as unknown as Blob
+/**
+ * A blob stand-in whose `type` and read behaviour are fully controlled. Slices
+ * inherit the read, so a rejecting stand-in rejects however it is read.
+ */
+function fakeBlob(
+    type: string,
+    read: () => Promise<ArrayBuffer>,
+    size = 0,
+): Blob {
+    return {
+        type,
+        size,
+        arrayBuffer: read,
+        slice: (start = 0, end = size) =>
+            fakeBlob(
+                type,
+                async () => (await read()).slice(start, end),
+                Math.max(0, Math.min(end, size) - start),
+            ),
+    } as unknown as Blob
 }
+
+/**
+ * A blob that records the size of every read made against it — the sniff's
+ * verdict says what it decided, `reads` says how much of the file it had to
+ * pull in to decide it.
+ */
+function countingBlob(
+    type: string,
+    bytes: Uint8Array,
+): { file: Blob; reads: number[] } {
+    const reads: number[] = []
+    const make = (start: number, end: number): Blob =>
+        ({
+            type,
+            size: end - start,
+            slice: (from = 0, to = end - start) =>
+                make(start + from, Math.min(start + to, end)),
+            arrayBuffer: () => {
+                reads.push(end - start)
+                return Promise.resolve(
+                    bytes.slice(start, end).buffer as ArrayBuffer,
+                )
+            },
+        }) as unknown as Blob
+    return { file: make(0, bytes.length), reads }
+}
+
+/** What `isAnimatedImage` sniffs before deciding whether to read on. */
+const SNIFF_PREFIX_BYTES = 64 * 1024
 
 describe('isAnimatedImage — GIF', () => {
     it('reports a single-frame GIF as still', async () => {
@@ -192,8 +239,10 @@ describe('isAnimatedImage — everything else', () => {
             gifFrame(0),
             GIF_TRAILER,
         )
-        const file = fakeBlob('IMAGE/GIF; charset=binary', () =>
-            Promise.resolve(bytes.buffer as ArrayBuffer),
+        const file = fakeBlob(
+            'IMAGE/GIF; charset=binary',
+            () => Promise.resolve(bytes.buffer as ArrayBuffer),
+            bytes.length,
         )
         await expect(isAnimatedImage(file)).resolves.toBe(true)
     })
@@ -203,5 +252,75 @@ describe('isAnimatedImage — everything else', () => {
             Promise.reject(new Error('stream errored')),
         )
         await expect(isAnimatedImage(file)).resolves.toBe(false)
+    })
+})
+
+// ─────────────────────────────────────────────
+// How much of the file the sniff reads
+//
+// compress and exif call this before touching the file, so a still photo now
+// pays for the sniff. Every format but GIF declares animation in its header,
+// and so does a looping GIF — only the multi-descriptor walk needs the rest.
+// ─────────────────────────────────────────────
+describe('isAnimatedImage — bytes read', () => {
+    it('decides a large still PNG from the prefix alone', async () => {
+        const bytes = concatBytes(
+            PNG_SIGNATURE,
+            pngChunk('IHDR', 13),
+            pngChunk('IDAT', 200_000),
+            pngChunk('IEND'),
+        )
+        const { file, reads } = countingBlob('image/png', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(false)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('decides a large animated WebP from the prefix alone', async () => {
+        const bytes = concatBytes(
+            animatedWebpBytes(),
+            riffChunk(
+                'VP8 ',
+                Array.from({ length: 80_000 }, () => 0),
+            ),
+        )
+        const { file, reads } = countingBlob('image/webp', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('short-circuits a large looping GIF from its header', async () => {
+        const bytes = concatBytes(
+            gifHeader(),
+            GIF_NETSCAPE_LOOP,
+            gifFrame(0),
+            gifComment(80 * 1024),
+            gifFrame(1),
+            GIF_TRAILER,
+        )
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('reads the whole GIF when its second frame sits past the prefix', async () => {
+        // No looping extension: the second Image Descriptor is the only tell,
+        // and it can sit anywhere in the stream.
+        const bytes = concatBytes(
+            gifHeader(),
+            gifFrame(0),
+            gifComment(80 * 1024),
+            gifFrame(1),
+            GIF_TRAILER,
+        )
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES, bytes.length])
+    })
+
+    it('does not read a GIF that fits inside the prefix twice', async () => {
+        const bytes = stillGifBytes()
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(false)
+        expect(reads).toEqual([bytes.length])
     })
 })

--- a/packages/core/tests/strategies/token-endpoint.test.ts
+++ b/packages/core/tests/strategies/token-endpoint.test.ts
@@ -331,4 +331,50 @@ describe('TokenEndpointCredentials — endpoint error body', () => {
         expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
         expect(err.status).toBe(502)
     })
+
+    it('keeps the legacy wording when a proxy answers with an HTML error page', async () => {
+        // nginx/Cloudflare answer a 502 with markup, not with the host's copy:
+        // surfacing it would hand `onError` 200 characters of `<html>`.
+        const creds = failWith({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: [
+                '<html>',
+                '<head><title>502 Bad Gateway</title></head>',
+                '<body>',
+                '<center><h1>502 Bad Gateway</h1></center>',
+                '<hr><center>nginx/1.24.0</center>',
+                '</body>',
+                '</html>',
+            ].join('\n'),
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+        expect(err.status).toBe(502)
+    })
+
+    it('keeps the legacy wording for an error page behind leading whitespace', async () => {
+        const creds = failWith({
+            status: 413,
+            statusText: 'Payload Too Large',
+            body: '\n  <!DOCTYPE html><html><body>413 Request Entity Too Large</body></html>',
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe(
+            'Presign request failed: 413 Payload Too Large',
+        )
+    })
+
+    it('still surfaces an XML body that carries a real error code', async () => {
+        // The guard is markup *without* a code — an S3-style body opens with a
+        // tag too, and its <Code>/<Message> pair is exactly what to surface.
+        const creds = failWith({
+            status: 403,
+            statusText: 'Forbidden',
+            body: '<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>',
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe('Access Denied')
+        expect(err.code).toBe('AccessDenied')
+    })
 })


### PR DESCRIPTION
Closes part of #367 — the three bounded follow-ups from the #364/#365 review that need no API or i18n decision.

**Covered: items 1, 3, 5.** **Still open: items 2 and 4** (the panel message for a host-supplied error code, and a runtime signal when the EXIF strip is skipped) — both need a public-API/i18n decision, so they stay on the issue. Item 6 is accepted behavior and untouched.

## 1 — HTML error pages no longer leak into `error.message`

`parseErrorBody`'s text fallback surfaces the first 200 characters of any unrecognised body, so an nginx/Cloudflare 502 or 413 page reached `onError` as raw markup where the strategy used to throw `Presign request failed: 502 Bad Gateway`. Markup carrying no error code is now treated as nothing to surface, and the legacy status-line wording is kept. An S3-style `<Error><Code>` body opens with a tag too and still comes through, because it parses to a real code.

Failing first (`tests/strategies/token-endpoint.test.ts`, 2 failed | 20 passed):

```
FAIL > keeps the legacy wording when a proxy answers with an HTML error page
- Presign request failed: 502 Bad Gateway
+ <html>
+ <head><title>502 Bad Gateway</title></head>
...
FAIL > keeps the legacy wording for an error page behind leading whitespace
AssertionError: expected '\n  <!DOCTYPE html><html><body>413 Re…' to be 'Presign request failed: 413 Payload T…'
```

## 3 — the message is computed before the error is constructed

`error.message` was reassigned after construction, so the body was parsed twice and the error briefly carried wording it never kept. `uploadErrorFromResponse` now decides the message itself: `fallbackMessage` supplies wording a caller must keep and `ignoreErrorPageBody` opts into the guard above, so `token-endpoint` is a single call with a single parse and no post-construction patching. Callers passing neither option are unaffected.

Failing first (`src/__tests__/errors.test.ts`, 2 failed | 46 passed):

```
FAIL > prefers the caller's fallback message over the status line
Expected: "Presign request failed: 502 Bad Gateway"
Received: "502 Bad Gateway"

FAIL > discards a proxy error page when the caller opts in
Expected: "Presign request failed: 502 Bad Gateway"
Received: "<html><body><h1>502 Bad Gateway</h1></body></html>"
```

One correction to the issue's premise, verified on Node 24.18.0: V8 formats `.stack` **lazily**, so the header shows the message at first access, not at construction — `new Error('before'); e.message = 'after'; e.stack` yields `"Error: after"`. The pre-fallback wording was therefore only visible to a reader that had already captured the stack, which nothing on this path does. The refactor still stands on the other half (one parse, no mutation of a constructed error) and is behavior-identical; there is no observable `.stack` difference to pin, which is why the RED tests above are on the mechanism rather than on the stack header.

## 5 — `isAnimatedImage` sniffs a 64 KiB prefix

The guard runs before `compress` and `exif`, so every image paid a full `file.arrayBuffer()` — a read the main-thread path never made before the guard existed. It now reads the first 64 KiB, where each format declares animation (APNG's `acTL` before the first `IDAT`, WebP's `VP8X`/`ANIM` at the top of the container, a looping GIF's `NETSCAPE2.0` extension in the header). Only a GIF that has announced nothing by then is read in full, because its second Image Descriptor can sit anywhere in the stream. Verdicts are unchanged; the new tests assert the byte ranges actually read, not just the verdict.

Failing first (`tests/steps/animated-image-detection.test.ts`, 4 failed | 22 passed):

```
FAIL > decides a large still PNG from the prefix alone
AssertionError: expected [ 200060 ] to deeply equal [ 65536 ]

FAIL > reads the whole GIF when its second frame sits past the prefix
AssertionError: expected [ 82295 ] to deeply equal [ 65536, 82295 ]
```

## Gates

| Gate | Result |
| --- | --- |
| `pnpm --filter @useupup/core test` | 143 files / **1741 passed**, exit 0 |
| `pnpm run test` (all packages) | 28/28 turbo tasks, exit 0 (first pass hit the known load-sensitive `@useupup/mastra` observability 5 s timeout; passes isolated 7/7 and on re-run) |
| `pnpm run typecheck` | 31/31 tasks, exit 0 |
| `prettier --check` on every touched file | clean, exit 0 |
| pre-commit (core + react + server suites) | green on each commit — core 1741, react 644, server 337 passed |
| pre-push (typecheck + lint + knip) | green |

Every command ran through `rtk proxy` with its raw exit code captured.

## Notes

- `@useupup/core`'s runtime export list is unchanged; `UploadErrorFromResponseArgs` gains two optional fields, so the `public-api` and `internal-surface` pins are untouched.
- `apps/landing/content/docs/api-reference/error-codes.mdx` gets one sentence: the presign fallback wording now also covers a proxy's error page.
- One patch changeset for `@useupup/core`.
