### PR TITLE
fix(ci): unblock the Playwright install and move the landing suite's port out of the ephemeral range

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,16 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Provision MinIO env (defaults; smoke is OAuth-free)
               run: cp local-dev/.env.minio.example local-dev/.env.minio
@@ -285,7 +294,16 @@ jobs:
               run: pnpm --filter @useupup/core --filter @useupup/react --filter @useupup/server build
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             # Flag-position --project (never the `-- --project` pnpm-forwarding
             # form, which Playwright reads as filename filters — see CLAUDE.md).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,16 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Provision MinIO env (defaults; suites are OAuth-free)
               run: cp local-dev/.env.minio.example local-dev/.env.minio
@@ -438,7 +447,12 @@ jobs:
 
             - name: Install Playwright Chromium
               if: steps.creds.outputs.present == 'true'
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # See the Full E2E job above: Google's chrome-stable apt index is
+              # serving a broken Packages.gz, and `--with-deps` fails on it.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Run landing feedback e2e + shared-PostHog ingestion verification
               if: steps.creds.outputs.present == 'true'

--- a/apps/e2e-test/playwright.landing.config.ts
+++ b/apps/e2e-test/playwright.landing.config.ts
@@ -13,7 +13,12 @@ import { defineConfig } from '@playwright/test'
 // The `flows` project (support + thumbs) runs first; the serial `ingestion`
 // project depends on it, so verification always runs LAST against landed data.
 
-const LANDING_PORT = 53080
+// 31080, not 53080: Linux draws ephemeral source ports from 32768-60999, so a
+// fixed listen port in that window can be transiently held by one of the
+// runner's own outbound connections — the failure mode that killed the
+// resume harness on :53062 (see apps/e2e-test/e2e/multipart-resume-harness.ts).
+// Below 32768 the kernel never competes for it.
+const LANDING_PORT = 31080
 const MASTRA_PORT = 4144
 const baseURL = `http://localhost:${LANDING_PORT}`
 


### PR DESCRIPTION
Two independent CI fixes. The first unblocks every Playwright job in the repo; the second moves one more fixed listen port below the Linux ephemeral range. **The storybook / cross-framework half of the port sweep is deliberately NOT here** — see "Not done" below; it needs a decision that belongs to the maintainer, not to this PR.

## 1 — drop Google's chrome-stable apt source before `playwright install`

Every Playwright job currently dies before it runs a test. Nightly run [34382957429](https://github.com/DevinoSolutions/upup/actions/runs/34382957429) on master, attempts 1 **and** 2, three separate jobs, step "Install Playwright Chromium":

```
Get:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
Err:29  https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Failed to fetch .../binary-amd64/Packages.gz  Hash Sum mismatch
Failed to install browsers
Error: Installation process exited with code: 100
```

Every Ubuntu archive source fetched fine; only Google's chrome-stable index is broken, and `--with-deps` runs `apt-get update` across all sources, so one bad third-party repo fails the step. Playwright downloads its own Chromium and takes system deps from the Ubuntu archives — it never needs that repo — so the fix is to remove the source list, not to retry a broken mirror.

Applied to all four install steps: `e2e.yml` (E2E, Docs-E2E) and `nightly.yml` (E2E-Full, Landing-Feedback — its `steps.creds.outputs.present` guard is kept). Nothing in `docs/`, `scripts/`, or `CONTRIBUTING.md` documents this step, so there was nothing to keep in sync (`grep -rn "playwright install\|with-deps\|chrome-stable" docs/ scripts/ CONTRIBUTING.md local-dev/*.md` → no hits).

## 2 — `53080` → `31080` (landing suite webServer)

| Port | Old | New | Where |
| --- | --- | --- | --- |
| Landing e2e webServer | 53080 | 31080 | `apps/e2e-test/playwright.landing.config.ts` |

Same class as the 53061/53062 fix in #378: Linux draws ephemeral source ports from 32768–60999, so a fixed listen port in that window can be transiently held by one of the runner's own outbound connections, and Playwright then polls a URL that never comes up. The reason is recorded beside the constant, pointing at the resume harness that documented the rule.

Method: a small Node codemod over `git ls-files` — exact-substring, longest-key-first, with an explicit KEEP list (`53000`, `53050`–`53056`, `53060`, `53070`). It rewrote **1 file**; `git grep 53080` now matches only the explanatory comment. `31050`–`31055`, `31060`, `31080` were verified free repo-wide beforehand (only `31061`/`31062` are taken, by the resume harness). `parity-fixtures.json` contains no port numbers at all, so no fixture regen is involved.

## Not done — the storybook ports (53050–53055) and the cf harness (53060)

Renumbering these would change **external service configuration**, which is the stop condition on this task:

- Each storybook's `.env.example` says: *"Add this Storybook's origin (`http://localhost:5305x`) to each provider's list of authorized JavaScript origins / redirect URIs in its developer console"*, and for OneDrive/Dropbox/Box *"redirectUri defaults to window origin"*. So the six origins are registered in four developer consoles (Google Cloud, Azure, Dropbox, Box).
- `local-dev/.env.ports` records the same fact: *"53056 sits inside the OAuth clients' registered redirect range (53050-53060)"*.
- #378's own commit message states the ruling explicitly: *":53060 … sits inside the OAuth clients' registered redirect range (53050-53060), so it is pinned by external registration, not by convention."*

Moving them silently breaks cloud-drive sign-in in the storybooks and the local playground until a human re-registers six origins in four consoles. Worth noting for whoever decides: the cf harness port is already env-overridable (`UPUP_E2E_SERVER_PORT`), while the six storybook ports are baked into each package's `storybook` script — so a CI-only override is a possible middle path that keeps the registered defaults intact.

`53000` (the landing dev default) is also inside the ephemeral range but is left alone deliberately: it is the documented local-dev convention block (`local-dev/LOCAL-DEV.md`, `local-dev/ports/landing.env`, `AGENTS_RULES.md`), not a CI listen port.

## Suspected, not proven

Attempt 1 of that nightly lost the cross-framework suite to a silent 900 s `Timed out waiting 900000ms from config.webServer` (job 102572070419) hours after a green ~52 s boot on dev. That is **consistent with** a storybook failing to bind a port inside the ephemeral range — Playwright only polls a URL and never surfaces the child's `EADDRINUSE` — but it is a hypothesis, not a demonstrated cause: the rerun died at the apt step before it ever reached the cross-framework job.

## Gates (all via `rtk proxy`, raw exit codes captured)

| Gate | Result |
| --- | --- |
| YAML parse of both workflows (`yaml` package; asserts all 4 install steps + the `if:` guard) | OK, exit 0 |
| `pnpm run typecheck` | 31/31 tasks, exit 0 |
| `pnpm --filter @useupup/e2e-test run typecheck` | exit 0 |
| `pnpm run test:quality` | 392 test files + 5 workflows clean, exit 0 |
| `prettier --check` on all 3 touched files | clean, exit 0 |
| pre-commit (core + react + server suites) | green on both commits |
| pre-push (typecheck + lint + knip) | green |

No package with unit tests was touched (`packages/angular`'s `server-mode-drive.spec.ts` references `:53060`, which this PR does not move), so no suite needed re-running beyond the hooks.
