### PR TITLE
Promote dev: #367 core follow-ups + nightly CI hardening

### DIFF
--- a/.changeset/prefix-sniff-clean-presign.md
+++ b/.changeset/prefix-sniff-clean-presign.md
@@ -1,0 +1,30 @@
+---
+'@useupup/core': patch
+---
+
+Presign failures no longer surface a reverse proxy's HTML error page, and the
+animated-image guard stops reading whole files.
+
+`TokenEndpointCredentials.getPresignedUrl` reads a failed presign body so the
+endpoint's own sentence reaches `onError`, but `parseErrorBody`'s text fallback
+also caught the error pages nginx and Cloudflare write for a 502 or 413 — so a
+handler that used to get `Presign request failed: 502 Bad Gateway` got 200
+characters of `<html>` instead. A markup body carrying no error code is now
+treated as nothing to surface and the status-line wording is kept. An S3-style
+`<Error><Code>` body is unaffected: it parses to a real code and still comes
+through. The error is also built with its final message rather than having
+`message` reassigned afterwards, so the body is parsed once and the error never
+carries wording it does not keep. `uploadErrorFromResponse` gained two optional
+arguments for this — `fallbackMessage` (wording to use when the body carries
+nothing) and `ignoreErrorPageBody` (opt into the markup guard); callers that
+pass neither behave exactly as before.
+
+`isAnimatedImage` — the guard that keeps `imageCompression` and `stripExifData`
+from flattening animated GIF/WebP/APNG — used to call `arrayBuffer()` on the
+whole file, a read the main-thread path never made before that guard existed,
+so a still 40 MB photo was materialized in full just to learn it was still. It
+now sniffs the first 64 KiB, which is where every one of these formats declares
+animation (APNG's `acTL` before the first `IDAT`, WebP's `VP8X`/`ANIM` at the
+top of the container, a looping GIF's `NETSCAPE2.0` extension in the header).
+Only a GIF that has announced nothing by then is read in full, because its
+second Image Descriptor can sit anywhere in the stream. Verdicts are unchanged.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,16 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Provision MinIO env (defaults; smoke is OAuth-free)
               run: cp local-dev/.env.minio.example local-dev/.env.minio
@@ -285,7 +294,16 @@ jobs:
               run: pnpm --filter @useupup/core --filter @useupup/react --filter @useupup/server build
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             # Flag-position --project (never the `-- --project` pnpm-forwarding
             # form, which Playwright reads as filename filters — see CLAUDE.md).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,16 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Playwright Chromium
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # Drop Google's chrome-stable apt source first: its index has been
+              # serving a broken Packages.gz ("Hash Sum mismatch", nightly run
+              # 34382957429, both attempts, three jobs), and `--with-deps` runs
+              # `apt-get update`, which fails the whole install with code 100.
+              # Playwright ships its own Chromium and takes system deps from the
+              # Ubuntu archives, so the repo is dead weight here.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Provision MinIO env (defaults; suites are OAuth-free)
               run: cp local-dev/.env.minio.example local-dev/.env.minio
@@ -438,7 +447,12 @@ jobs:
 
             - name: Install Playwright Chromium
               if: steps.creds.outputs.present == 'true'
-              run: pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
+              # See the Full E2E job above: Google's chrome-stable apt index is
+              # serving a broken Packages.gz, and `--with-deps` fails on it.
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+                  sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+                  pnpm --filter @useupup/e2e-test exec playwright install --with-deps chromium
 
             - name: Run landing feedback e2e + shared-PostHog ingestion verification
               if: steps.creds.outputs.present == 'true'

--- a/apps/e2e-test/playwright.landing.config.ts
+++ b/apps/e2e-test/playwright.landing.config.ts
@@ -13,7 +13,12 @@ import { defineConfig } from '@playwright/test'
 // The `flows` project (support + thumbs) runs first; the serial `ingestion`
 // project depends on it, so verification always runs LAST against landed data.
 
-const LANDING_PORT = 53080
+// 31080, not 53080: Linux draws ephemeral source ports from 32768-60999, so a
+// fixed listen port in that window can be transiently held by one of the
+// runner's own outbound connections — the failure mode that killed the
+// resume harness on :53062 (see apps/e2e-test/e2e/multipart-resume-harness.ts).
+// Below 32768 the kernel never competes for it.
+const LANDING_PORT = 31080
 const MASTRA_PORT = 4144
 const baseURL = `http://localhost:${LANDING_PORT}`
 

--- a/apps/landing/content/docs/api-reference/error-codes.mdx
+++ b/apps/landing/content/docs/api-reference/error-codes.mdx
@@ -247,9 +247,10 @@ uploads.
 
 The presign call a custom `uploadEndpoint` makes routes through it too, so the
 sentence your endpoint writes into a non-2xx body is what `onError` receives —
-you do not have to recover it from an HTTP status. When the body is empty or
-unreadable the message stays `Presign request failed: <status> <statusText>`,
-the wording that path has always thrown.
+you do not have to recover it from an HTTP status. When the body is empty,
+unreadable, or an HTML error page a reverse proxy wrote with no error code of
+its own, the message stays `Presign request failed: <status> <statusText>`, the
+wording that path has always thrown.
 
 ```typescript
 import { uploadErrorFromResponse } from '@useupup/core'

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -401,4 +401,52 @@ describe('uploadErrorFromResponse', () => {
         expect(err.message).toContain('500')
         expect(err.status).toBe(500)
     })
+
+    it("prefers the caller's fallback message over the status line", () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '',
+            kind: 'network',
+            fallbackMessage: 'Presign request failed: 502 Bad Gateway',
+        })
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+    })
+
+    it('discards a proxy error page when the caller opts in', () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+            kind: 'network',
+            ignoreErrorPageBody: true,
+            fallbackMessage: 'Presign request failed: 502 Bad Gateway',
+        })
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+    })
+
+    it('keeps a code-carrying XML body even with the error-page guard on', () => {
+        const err = uploadErrorFromResponse({
+            status: 403,
+            statusText: 'Forbidden',
+            body: '<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>',
+            kind: 'network',
+            ignoreErrorPageBody: true,
+            fallbackMessage: 'Presign request failed: 403 Forbidden',
+        })
+        expect(err.message).toBe('Access Denied')
+        expect(err.code).toBe('AccessDenied')
+    })
+
+    it('leaves a markup body alone for callers that do not opt in', () => {
+        const err = uploadErrorFromResponse({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+            kind: 'network',
+        })
+        expect(err.message).toBe(
+            '<html><body><h1>502 Bad Gateway</h1></body></html>',
+        )
+    })
 })

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -193,6 +193,24 @@ export interface UploadErrorFromResponseArgs {
     operation?: UpupStorageError['operation']
     /** Provider label for storage/auth errors (e.g. 'S3', 'google-drive'). Defaults to 'server'. */
     provider?: string
+    /**
+     * Message to use when the body carries nothing worth surfacing. Defaults
+     * to `${status} ${statusText}`; a caller passes its own to keep wording it
+     * has always thrown.
+     */
+    fallbackMessage?: string
+    /**
+     * Treat a markup body carrying no error code as nothing worth surfacing.
+     * A reverse proxy or CDN answers 502/413 with an HTML error page, and the
+     * text fallback would otherwise put 200 characters of it in `message`. An
+     * S3-style `<Error><Code>` body is unaffected — it parses to a real code.
+     */
+    ignoreErrorPageBody?: boolean
+}
+
+/** An HTML/XML body, told from the host's own copy by its opening tag. */
+function isMarkupBody(body: string | undefined): boolean {
+    return body !== undefined && body.trimStart().startsWith('<')
 }
 
 /**
@@ -205,9 +223,24 @@ export interface UploadErrorFromResponseArgs {
 export function uploadErrorFromResponse(
     args: UploadErrorFromResponseArgs,
 ): UpupError {
-    const { status, statusText, body, kind, operation, provider } = args
+    const {
+        status,
+        statusText,
+        body,
+        kind,
+        operation,
+        provider,
+        fallbackMessage,
+        ignoreErrorPageBody,
+    } = args
     const parsed = parseErrorBody(body)
-    const message = parsed.message || `${status} ${statusText}`.trim()
+    const surfaced =
+        ignoreErrorPageBody && !parsed.code && isMarkupBody(body)
+            ? ''
+            : parsed.message
+    const message = surfaced.trim()
+        ? surfaced
+        : (fallbackMessage ?? `${status} ${statusText}`.trim())
 
     let err: UpupError
     if (kind === 'auth') {

--- a/packages/core/src/steps/animated-image.ts
+++ b/packages/core/src/steps/animated-image.ts
@@ -9,10 +9,9 @@
  * instead.
  *
  * Detection is byte-level rather than `ImageDecoder`-based so it behaves the
- * same in every browser and is deterministic under test. Reading the whole
- * blob is cheaper than what the step does next either way — the worker path
- * already calls `file.arrayBuffer()`, and the main-thread path hands the file
- * to `createImageBitmap`, which decodes it to raw RGBA.
+ * same in every browser and is deterministic under test. It reads a prefix
+ * rather than the file: a still photo is the common case, and the main-thread
+ * path never materialised the bytes at all before this guard existed.
  */
 
 function ascii(bytes: Uint8Array, start: number, length: number): string {
@@ -180,14 +179,31 @@ function baseMimeType(type: string): string {
 }
 
 /**
+ * How much of the file the sniff reads before deciding. Every format declares
+ * animation near the front — APNG's `acTL` precedes the first `IDAT`, WebP's
+ * `VP8X`/`ANIM` open the RIFF container, and a looping GIF carries its
+ * NETSCAPE2.0 extension in the header — so 64 KiB answers all of them.
+ */
+const SNIFF_PREFIX_BYTES = 64 * 1024
+
+/**
  * True when the blob is an animated image in one of the three formats a canvas
  * re-encode would flatten. Anything else — including formats with no animated
  * variant — is false, so callers process it as before.
  */
 export async function isAnimatedImage(file: Blob): Promise<boolean> {
-    const sniff = SNIFFERS[baseMimeType(file.type)]
+    const type = baseMimeType(file.type)
+    const sniff = SNIFFERS[type]
     if (!sniff) return false
     try {
+        const prefix = new Uint8Array(
+            await file.slice(0, SNIFF_PREFIX_BYTES).arrayBuffer(),
+        )
+        if (sniff(prefix)) return true
+        // A GIF that does not announce itself in the header is only settled by
+        // the multi-descriptor walk, and the second descriptor can sit anywhere
+        // in the stream. No other format needs the rest of the bytes.
+        if (type !== 'image/gif' || file.size <= prefix.length) return false
         return sniff(new Uint8Array(await file.arrayBuffer()))
     } catch {
         // upup-catch: unreadable blob — let the step's own decode surface it

--- a/packages/core/src/strategies/token-endpoint.ts
+++ b/packages/core/src/strategies/token-endpoint.ts
@@ -21,6 +21,17 @@ async function readErrorBody(response: Response): Promise<string | undefined> {
     }
 }
 
+/**
+ * True when the body is markup rather than the endpoint's own copy. A reverse
+ * proxy or CDN answers 502/413 with an HTML error page, and `parseErrorBody`'s
+ * text fallback would otherwise surface 200 characters of it as the message.
+ * Callers pair this with "and the parse found no code", so an S3-style
+ * `<Error><Code>…` body — markup that does carry a code — still gets through.
+ */
+function looksLikeErrorPage(body: string | undefined): boolean {
+    return body !== undefined && body.trimStart().startsWith('<')
+}
+
 export class TokenEndpointCredentials implements CredentialStrategy {
     private url: string
     private headers: Record<string, string>
@@ -58,7 +69,11 @@ export class TokenEndpointCredentials implements CredentialStrategy {
                 ...(body !== undefined ? { body } : {}),
                 kind: 'network',
             })
-            if (!parseErrorBody(body).message.trim()) {
+            const parsed = parseErrorBody(body)
+            if (
+                !parsed.message.trim() ||
+                (!parsed.code && looksLikeErrorPage(body))
+            ) {
                 // Nothing usable in the body — keep the exact wording this
                 // strategy has always thrown, so a consumer matching on it
                 // sees no change.

--- a/packages/core/src/strategies/token-endpoint.ts
+++ b/packages/core/src/strategies/token-endpoint.ts
@@ -1,5 +1,4 @@
 import {
-    parseErrorBody,
     uploadErrorFromResponse,
     type CredentialStrategy,
     type FileMetadata,
@@ -19,17 +18,6 @@ async function readErrorBody(response: Response): Promise<string | undefined> {
         // upup-catch: body unreadable — fall back to the status-only message
         return undefined
     }
-}
-
-/**
- * True when the body is markup rather than the endpoint's own copy. A reverse
- * proxy or CDN answers 502/413 with an HTML error page, and `parseErrorBody`'s
- * text fallback would otherwise surface 200 characters of it as the message.
- * Callers pair this with "and the parse found no code", so an S3-style
- * `<Error><Code>…` body — markup that does carry a code — still gets through.
- */
-function looksLikeErrorPage(body: string | undefined): boolean {
-    return body !== undefined && body.trimStart().startsWith('<')
 }
 
 export class TokenEndpointCredentials implements CredentialStrategy {
@@ -63,22 +51,20 @@ export class TokenEndpointCredentials implements CredentialStrategy {
             // left consumers matching HTTP statuses out of upup's own message
             // text to recover what their server had already said.
             const body = await readErrorBody(response)
+            // Bound to a const so the error is thrown as constructed — the
+            // taxonomy lint reads a thrown call expression as a literal.
             const error = uploadErrorFromResponse({
                 status: response.status,
                 statusText: response.statusText,
                 ...(body !== undefined ? { body } : {}),
                 kind: 'network',
-            })
-            const parsed = parseErrorBody(body)
-            if (
-                !parsed.message.trim() ||
-                (!parsed.code && looksLikeErrorPage(body))
-            ) {
-                // Nothing usable in the body — keep the exact wording this
+                // An empty body, or an error page a reverse proxy wrote,
+                // carries nothing to surface: keep the exact wording this
                 // strategy has always thrown, so a consumer matching on it
                 // sees no change.
-                error.message = `Presign request failed: ${response.status} ${response.statusText}`
-            }
+                ignoreErrorPageBody: true,
+                fallbackMessage: `Presign request failed: ${response.status} ${response.statusText}`,
+            })
             throw error
         }
 

--- a/packages/core/tests/helpers/animated-image-fixtures.ts
+++ b/packages/core/tests/helpers/animated-image-fixtures.ts
@@ -70,6 +70,24 @@ export const GIF_NETSCAPE_LOOP = concatBytes(
     [0x03, 0x01, 0x00, 0x00, 0x00],
 )
 
+/**
+ * A Comment Extension carrying `length` bytes of filler, in the 255-byte
+ * sub-blocks the format requires. Lets a fixture push a later frame past a
+ * chosen offset without inventing an illegal container.
+ */
+export function gifComment(length: number): number[] {
+    const bytes = [0x21, 0xfe]
+    let left = length
+    while (left > 0) {
+        const size = Math.min(255, left)
+        bytes.push(size)
+        for (let i = 0; i < size; i += 1) bytes.push(0x20)
+        left -= size
+    }
+    bytes.push(0x00) // sub-block terminator
+    return bytes
+}
+
 /** Graphic Control Extension — legal on a single-frame GIF too. */
 export const GIF_GRAPHIC_CONTROL = [
     0x21, 0xf9, 0x04, 0x00, 0x0a, 0x00, 0x00, 0x00,

--- a/packages/core/tests/steps/animated-image-detection.test.ts
+++ b/packages/core/tests/steps/animated-image-detection.test.ts
@@ -4,6 +4,7 @@ import {
     concatBytes,
     gifHeader,
     gifFrame,
+    gifComment,
     riffChunk,
     pngChunk,
     vp8xChunk,
@@ -26,10 +27,56 @@ function image(type: string, ...parts: BytePart[]): Blob {
     return new Blob([concatBytes(...parts)], { type })
 }
 
-/** A blob stand-in whose `type` and read behaviour are fully controlled. */
-function fakeBlob(type: string, read: () => Promise<ArrayBuffer>): Blob {
-    return { type, arrayBuffer: read } as unknown as Blob
+/**
+ * A blob stand-in whose `type` and read behaviour are fully controlled. Slices
+ * inherit the read, so a rejecting stand-in rejects however it is read.
+ */
+function fakeBlob(
+    type: string,
+    read: () => Promise<ArrayBuffer>,
+    size = 0,
+): Blob {
+    return {
+        type,
+        size,
+        arrayBuffer: read,
+        slice: (start = 0, end = size) =>
+            fakeBlob(
+                type,
+                async () => (await read()).slice(start, end),
+                Math.max(0, Math.min(end, size) - start),
+            ),
+    } as unknown as Blob
 }
+
+/**
+ * A blob that records the size of every read made against it — the sniff's
+ * verdict says what it decided, `reads` says how much of the file it had to
+ * pull in to decide it.
+ */
+function countingBlob(
+    type: string,
+    bytes: Uint8Array,
+): { file: Blob; reads: number[] } {
+    const reads: number[] = []
+    const make = (start: number, end: number): Blob =>
+        ({
+            type,
+            size: end - start,
+            slice: (from = 0, to = end - start) =>
+                make(start + from, Math.min(start + to, end)),
+            arrayBuffer: () => {
+                reads.push(end - start)
+                return Promise.resolve(
+                    bytes.slice(start, end).buffer as ArrayBuffer,
+                )
+            },
+        }) as unknown as Blob
+    return { file: make(0, bytes.length), reads }
+}
+
+/** What `isAnimatedImage` sniffs before deciding whether to read on. */
+const SNIFF_PREFIX_BYTES = 64 * 1024
 
 describe('isAnimatedImage — GIF', () => {
     it('reports a single-frame GIF as still', async () => {
@@ -192,8 +239,10 @@ describe('isAnimatedImage — everything else', () => {
             gifFrame(0),
             GIF_TRAILER,
         )
-        const file = fakeBlob('IMAGE/GIF; charset=binary', () =>
-            Promise.resolve(bytes.buffer as ArrayBuffer),
+        const file = fakeBlob(
+            'IMAGE/GIF; charset=binary',
+            () => Promise.resolve(bytes.buffer as ArrayBuffer),
+            bytes.length,
         )
         await expect(isAnimatedImage(file)).resolves.toBe(true)
     })
@@ -203,5 +252,75 @@ describe('isAnimatedImage — everything else', () => {
             Promise.reject(new Error('stream errored')),
         )
         await expect(isAnimatedImage(file)).resolves.toBe(false)
+    })
+})
+
+// ─────────────────────────────────────────────
+// How much of the file the sniff reads
+//
+// compress and exif call this before touching the file, so a still photo now
+// pays for the sniff. Every format but GIF declares animation in its header,
+// and so does a looping GIF — only the multi-descriptor walk needs the rest.
+// ─────────────────────────────────────────────
+describe('isAnimatedImage — bytes read', () => {
+    it('decides a large still PNG from the prefix alone', async () => {
+        const bytes = concatBytes(
+            PNG_SIGNATURE,
+            pngChunk('IHDR', 13),
+            pngChunk('IDAT', 200_000),
+            pngChunk('IEND'),
+        )
+        const { file, reads } = countingBlob('image/png', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(false)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('decides a large animated WebP from the prefix alone', async () => {
+        const bytes = concatBytes(
+            animatedWebpBytes(),
+            riffChunk(
+                'VP8 ',
+                Array.from({ length: 80_000 }, () => 0),
+            ),
+        )
+        const { file, reads } = countingBlob('image/webp', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('short-circuits a large looping GIF from its header', async () => {
+        const bytes = concatBytes(
+            gifHeader(),
+            GIF_NETSCAPE_LOOP,
+            gifFrame(0),
+            gifComment(80 * 1024),
+            gifFrame(1),
+            GIF_TRAILER,
+        )
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES])
+    })
+
+    it('reads the whole GIF when its second frame sits past the prefix', async () => {
+        // No looping extension: the second Image Descriptor is the only tell,
+        // and it can sit anywhere in the stream.
+        const bytes = concatBytes(
+            gifHeader(),
+            gifFrame(0),
+            gifComment(80 * 1024),
+            gifFrame(1),
+            GIF_TRAILER,
+        )
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(true)
+        expect(reads).toEqual([SNIFF_PREFIX_BYTES, bytes.length])
+    })
+
+    it('does not read a GIF that fits inside the prefix twice', async () => {
+        const bytes = stillGifBytes()
+        const { file, reads } = countingBlob('image/gif', bytes)
+        await expect(isAnimatedImage(file)).resolves.toBe(false)
+        expect(reads).toEqual([bytes.length])
     })
 })

--- a/packages/core/tests/strategies/token-endpoint.test.ts
+++ b/packages/core/tests/strategies/token-endpoint.test.ts
@@ -331,4 +331,50 @@ describe('TokenEndpointCredentials — endpoint error body', () => {
         expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
         expect(err.status).toBe(502)
     })
+
+    it('keeps the legacy wording when a proxy answers with an HTML error page', async () => {
+        // nginx/Cloudflare answer a 502 with markup, not with the host's copy:
+        // surfacing it would hand `onError` 200 characters of `<html>`.
+        const creds = failWith({
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: [
+                '<html>',
+                '<head><title>502 Bad Gateway</title></head>',
+                '<body>',
+                '<center><h1>502 Bad Gateway</h1></center>',
+                '<hr><center>nginx/1.24.0</center>',
+                '</body>',
+                '</html>',
+            ].join('\n'),
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe('Presign request failed: 502 Bad Gateway')
+        expect(err.status).toBe(502)
+    })
+
+    it('keeps the legacy wording for an error page behind leading whitespace', async () => {
+        const creds = failWith({
+            status: 413,
+            statusText: 'Payload Too Large',
+            body: '\n  <!DOCTYPE html><html><body>413 Request Entity Too Large</body></html>',
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe(
+            'Presign request failed: 413 Payload Too Large',
+        )
+    })
+
+    it('still surfaces an XML body that carries a real error code', async () => {
+        // The guard is markup *without* a code — an S3-style body opens with a
+        // tag too, and its <Code>/<Message> pair is exactly what to surface.
+        const creds = failWith({
+            status: 403,
+            statusText: 'Forbidden',
+            body: '<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>',
+        })
+        const err = await presignError(creds)
+        expect(err.message).toBe('Access Denied')
+        expect(err.code).toBe('AccessDenied')
+    })
 })


### PR DESCRIPTION
Promotes two PRs already merged to `dev`, both with green rollups.

## #381 — issue #367 follow-ups (core)
- Proxy/CDN HTML error pages no longer replace the presign status line. `parseErrorBody`'s text fallback was surfacing 200 characters of raw nginx/Cloudflare HTML in `error.message` where callers used to get `Presign request failed: 502 Bad Gateway`.
- The presign error now gets its final message at construction instead of being reassigned afterwards, which also drops a redundant second `parseErrorBody` call.
- `isAnimatedImage` sniffs a 64 KiB prefix (enough for APNG `acTL`, WebP `VP8X`/`ANIM`, and the GIF `NETSCAPE2.0` short-circuit) instead of materialising the whole file, falling back to a full read only for the multi-descriptor GIF walk.

Each fix was driven from a failing test first. Issue #367 items 2, 4 and 6 stay open — they need a public-API/i18n decision, not a bug fix.

Note on item 3: the issue claimed the reassigned message left a stale `.stack` header. V8 formats `.stack` lazily, so that symptom was never observable; the refactor landed on its own merits (one parse, no mutation of a constructed error) rather than as a bug fix.

## #382 — nightly CI hardening
- All four `playwright install --with-deps chromium` steps now drop Google's chrome-stable apt source first. `--with-deps` runs `apt-get update`, which on the runner image also refreshes that repo; its index served a broken `Packages.gz` (`Hash Sum mismatch`) and failed the whole install with exit 100 across three jobs and both attempts of nightly run 34382957429, while every Ubuntu archive source fetched fine. Playwright ships its own Chromium and takes system deps from the Ubuntu archives, so the repo is dead weight here. The failure is intermittent, not a permanent outage.
- The landing suite's listen port moves `53080 → 31080`, out of Linux's ephemeral source-port range (32768–60999).

The six cross-framework storybook ports (53050–53055) and the cf harness (53060) are deliberately NOT moved: they are hand-registered as authorized JavaScript origins / redirect URIs in four OAuth provider consoles, so renumbering them silently breaks local drive popups.

Attempt 1 of that nightly run also lost the cross-framework suite to a silent 900 s `webServer` timeout. That is **unexplained, not fixed here** — candidates are an ephemeral-port collision or six cold storybook compiles exceeding the budget on a loaded runner. It did not reproduce (#381's run passed the same suite green). If it recurs, the next step is diagnostic before structural: log the ports actually bound and each storybook's own ready line.