### PR TITLE
chore: post-release hygiene — action SHA pins, publish.yml precondition, CLAUDE.md sweep

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,7 +153,7 @@ jobs:
             # nothing, which means the capture layer itself broke.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: e2e-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -162,7 +162,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: e2e-playwright-artifacts
                   path: |
@@ -312,7 +312,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: docs-e2e-playwright-artifacts
                   path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
               run: pnpm run vocab:check
 
             - name: Archive code coverage results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: code-coverage-report
                   path: coverage/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,7 +110,7 @@ jobs:
             # future snapvisor.io baseline feed.
             - name: Upload visual product-state screenshots
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: nightly-visual-screenshots
                   path: apps/e2e-test/screenshots/
@@ -119,7 +119,7 @@ jobs:
 
             - name: Upload Playwright traces and reports
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: nightly-playwright-artifacts
                   path: |
@@ -391,7 +391,7 @@ jobs:
 
             - name: Upload Lighthouse reports
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: nightly-lighthouse-reports
                   path: apps/landing/.lighthouseci-reports/
@@ -470,7 +470,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure() && steps.creds.outputs.present == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: landing-feedback-playwright-artifacts
                   path: |

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -4,27 +4,27 @@ name: Publish npm placeholder
 # this workflow deliberately does NOT trigger on `release` — it must never
 # fire as a side effect of that flow.
 on:
-  workflow_dispatch:
+    workflow_dispatch:
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: sdk
-    permissions:
-      contents: read
-      # Required for npm trusted publishing (OIDC). No NPM_TOKEN secret is used.
-      id-token: write
-    steps:
-      - uses: actions/checkout@v7
+    publish:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: sdk
+        permissions:
+            contents: read
+            # Required for npm trusted publishing (OIDC). No NPM_TOKEN secret is used.
+            id-token: write
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
 
-      # Trusted publishing requires npm >= 11.5.1; setup-node ships an older npm.
-      - run: npm install -g npm@latest
+            # Trusted publishing requires npm >= 11.5.1; setup-node ships an older npm.
+            - run: npm install -g npm@latest
 
-      - run: npm publish --access public
+            - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,16 +124,21 @@ jobs:
               if: github.ref == 'refs/heads/master' && steps.changesets.outputs.hasChangesets == 'false' && steps.package_meta.outputs.any_needs_publish == 'true'
               run: pnpm run smoke:packages
 
-            # Auth: OIDC trusted publishing ONLY — every @useupup package has its
-            # trusted publisher configured on npmjs.com (repo DevinoSolutions/upup,
-            # workflow publish.yml, configured 2026-08-01). With id-token:write
-            # (above) + Node >=22.14 + npm >=11.5.1, npm exchanges the GitHub OIDC
-            # token automatically; no registry secret, no registry-url .npmrc (a
-            # token-referencing .npmrc would preempt the OIDC path). The npm
-            # upgrade MUST come after this setup-node: switching Node replaces the
-            # active npm with that Node's bundled version, which is below the
-            # trusted-publishing floor — upgrading before the switch is a no-op
-            # (that exact ordering bug broke the first 3.1.0 publish attempt).
+            # Auth: OIDC trusted publishing ONLY — id-token:write (above) + Node
+            # >=22.14 + npm >=11.5.1 let npm exchange the GitHub OIDC token
+            # automatically; no registry secret, no registry-url .npmrc (a
+            # token-referencing .npmrc would preempt the OIDC path).
+            # PRECONDITION: every @useupup package must have an npm trusted
+            # publisher configured on npmjs.com (GitHub Actions, repo
+            # DevinoSolutions/upup, workflow publish.yml). A package without one
+            # fails its own publish and therefore this job — but its version
+            # number is NOT burned, so the fix is to add the publisher and
+            # re-run. Verify each package's npm "access" page before merging a
+            # Version Packages PR. The npm upgrade MUST come after this
+            # setup-node: switching Node replaces the active npm with that
+            # Node's bundled version, which is below the trusted-publishing
+            # floor — upgrading before the switch is a no-op (that exact
+            # ordering bug broke the first 3.1.0 publish attempt).
             - name: Set up Node 22 for OIDC publish
               if: github.ref == 'refs/heads/master' && steps.changesets.outputs.hasChangesets == 'false' && steps.package_meta.outputs.any_needs_publish == 'true'
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,20 @@ upup — an MIT-licensed file uploader: one headless core plus native UI package
 for every major framework, with optional server-mode uploads (client → your
 server → S3-compatible storage) and cloud-drive sources (Google Drive, OneDrive,
 Dropbox, Box), camera, screen capture, and link imports. pnpm workspace + turbo;
-publishable packages are `@upupjs/*`, released together via changesets.
+publishable packages are `@useupup/*`, released together via changesets.
 
 ## Package map
 
 Publishable (`packages/`):
 
-- `@upupjs/core` — headless engine: file state + orchestrator, upload pipeline
+- `@useupup/core` — headless engine: file state + orchestrator, upload pipeline
   (compression, HEIC, web-worker offload), cloud-drive plugins, UI controllers,
   i18n, theme. **Zero framework dependencies — keep it that way.** The public
   `.` entry is a curated allow-list — every export is named explicitly, no
   `export *` — currently 53 values / 74 types (a snapshot, not a ceiling to
   preserve). Implementation details (`FileManager`, `UploadManager`,
   `PipelineEngine`, the orchestrator, controllers, context shapes, the
-  multipart-session store, low-level utils) live behind `@upupjs/core/internal`,
+  multipart-session store, low-level utils) live behind `@useupup/core/internal`,
   a deep-import-only subpath alongside the existing `./contracts`/`./i18n`/
   `./theme`/`./strategies` pattern — if you need one of them outside core's own
   `src/`, import it from `./internal`, never re-add it to the public entry.
@@ -32,30 +32,30 @@ Publishable (`packages/`):
   (ng-packagr cannot resolve `exports` conditional subpaths — angular's
   library build throws TS2307 without it), and a
   `packages/core/vitest.config.ts` alias entry placed BEFORE the bare
-  `@upupjs/core` key (Vite matches aliases in object order; the bare key
+  `@useupup/core` key (Vite matches aliases in object order; the bare key
   prefix-shadows subpaths — do not alphabetize).
-  Every one of the nine `@upupjs/*` packages carries a `public-api.test.ts`
+  Every one of the nine `@useupup/*` packages carries a `public-api.test.ts`
   (or `.spec.ts`, matching that package's own vitest convention) pinning its
   exact runtime export list, plus core alone also pins `./internal`'s list
   (`tests/internal-surface.test.ts`) — a name silently added or removed from
   either surface is a real API change the pin will catch; update the checked-in
   list deliberately, don't loosen the assertion to make it pass.
-- `@upupjs/react` — the canonical UI. Every other framework matches its DOM.
-- `@upupjs/vue`, `@upupjs/svelte`, `@upupjs/angular`, `@upupjs/vanilla` — native ports
+- `@useupup/react` — the canonical UI. Every other framework matches its DOM.
+- `@useupup/vue`, `@useupup/svelte`, `@useupup/angular`, `@useupup/vanilla` — native ports
   of the React UI (same DOM contract, same Tailwind classes).
-- `@upupjs/preact` — compat re-export of `@upupjs/react` via `preact/compat`; the
+- `@useupup/preact` — compat re-export of `@useupup/react` via `preact/compat`; the
   image editor lazily loads real React as an isolated island.
-- `@upupjs/next` — client re-export plus `/server` route handlers (App and Pages
+- `@useupup/next` — client re-export plus `/server` route handlers (App and Pages
   routers).
-- `@upupjs/server` — server-mode endpoints: S3/MinIO presign + proxy upload,
+- `@useupup/server` — server-mode endpoints: S3/MinIO presign + proxy upload,
   drive-token exchange, HMAC-signed trust model (signed length, key/uploadId
   binding, required secrets). Node<->Web request/response bridging for the
-  Node adapters (express/fastify/`@upupjs/next`'s pages-handler) lives in ONE
-  place — `@upupjs/server/node-bridge` (`toWebRequest`/`writeWebResponse`); a
+  Node adapters (express/fastify/`@useupup/next`'s pages-handler) lives in ONE
+  place — `@useupup/server/node-bridge` (`toWebRequest`/`writeWebResponse`); a
   future custom Node adapter imports it rather than re-hand-rolling the
   conversion. `createUpupHandler` requires `storage.type` to be an S3 /
   S3-compatible provider — it throws at construct time for a value with no
-  S3 surface (`NON_S3_STORAGE_PROVIDERS` in `@upupjs/core`, currently just
+  S3 surface (`NON_S3_STORAGE_PROVIDERS` in `@useupup/core`, currently just
   `azure`); `hono.ts`/`next.ts` (App Router) are web-native and don't need
   the bridge. `handler.ts` is decomposed by concern (the deferred N4 server
   decomposition, now done — P15): `respond.ts` is the single CORS-safe response
@@ -80,7 +80,7 @@ Private (`packages/`): `interactive-example`, `storybook-config`,
 `tailwind-config` (shared Tailwind/postcss factory — theme edits happen in one
 file, not per-package), `eslint-config` (shared flat-config factory mirroring
 `tailwind-config`; phase 1 lints TS/JS only — `.vue`/`.svelte` SFC and Angular
-HTML templates are deferred to phase 2; `@upupjs/react`/`@upupjs/preact`
+HTML templates are deferred to phase 2; `@useupup/react`/`@useupup/preact`
 additionally compose its `reactHooksConfig` named export — kept out of the
 shared default because vue/svelte composables are also named `use*` and would
 false-positive against `react-hooks/rules-of-hooks`).
@@ -94,7 +94,7 @@ svelte/vanilla/angular/preact` (per-framework style-parity references),
 
 ## Non-negotiable principles
 
-1. **React is the visual canon.** UI changes land in `@upupjs/react` first; the
+1. **React is the visual canon.** UI changes land in `@useupup/react` first; the
    other frameworks are then made DOM-identical (the parity harness enforces
    this byte-for-byte).
 2. **No smoke-test theater.** "It renders" is not verification. Features are
@@ -107,15 +107,15 @@ svelte/vanilla/angular/preact` (per-framework style-parity references),
    abstractions that make single-framework edits harder to reason about.
 5. **Rebuild before dependents see your edit.** Packages consume each other's
    `dist/`, not `src/`. After editing `packages/core/src`, run
-   `pnpm --filter @upupjs/core build` (same idea for any `packages/*` edit)
-   unless the `pnpm run dev:package` watchers are running. Trap: `@upupjs/preact`
+   `pnpm --filter @useupup/core build` (same idea for any `packages/*` edit)
+   unless the `pnpm run dev:package` watchers are running. Trap: `@useupup/preact`
    tests exercise its BUILT bundle (which inlines react), so after react/core
    edits rebuild react + preact before trusting preact test results — a stale
    dist fails with errors whose sourcemaps point at up-to-date `src/` files.
 6. **Keep core's mandatory path lean.** Heavy capabilities are opt-in:
    `libheif-js` (HEIC) and `tus-js-client` (resumable) are
    `optionalDependencies` loaded via dynamic `import()` behind subpath exports
-   (`@upupjs/core/steps/heic`, `@upupjs/core/strategies/tus-upload`), and the
+   (`@useupup/core/steps/heic`, `@useupup/core/strategies/tus-upload`), and the
    pipeline worker is a separate module, not inlined. Never add a static
    top-level import of a heavy dependency to core's main entry.
    `.size-limit.json` holds the per-package budgets; `pnpm run size` enforces.
@@ -125,7 +125,7 @@ svelte/vanilla/angular/preact` (per-framework style-parity references),
    `packages/server/tests/handler-extended.test.ts` and
    `tests/integration/trust-model.integration.test.ts` assert this — a handler
    change that only passes by loosening a check is the wrong change.
-   `@upupjs/server` upload routes (`/presign`, `/multipart/init`) are
+   `@useupup/server` upload routes (`/presign`, `/multipart/init`) are
    secure-by-default: they 403 `AUTH_REQUIRED` unless `auth`, `getUserId`, or
    the explicit opt-in `allowAnonymousUploads:true` is configured. The upload
    token's `uid` is enforced on the multipart continuation routes
@@ -146,7 +146,7 @@ pnpm run e2e            # the REAL gate — see next section
 pnpm run prettier-check # CI blocks on this (all 9 publishable packages' src, .ts/.tsx ONLY — .vue/.svelte SFC + .css are NOT covered; one root config)
 pnpm run size           # size-limit bundle budgets
 pnpm run audit:prod     # high+ advisories in the publishable prod trees
-pnpm run lint           # eslint flat-config: 9 @upupjs/* packages + 3 apps (playground, landing, docs); each leaf is `eslint . --max-warnings 0` so warnings gate (F-784)
+pnpm run lint           # eslint flat-config: 9 @useupup/* packages + 3 apps (playground, landing, docs); each leaf is `eslint . --max-warnings 0` so warnings gate (F-784)
 pnpm run lint:ox        # oxlint fast first-line (built-ins only, seconds)
 pnpm run knip           # dead-code / unused-dep detection (workspace-aware)
 pnpm run env:check      # .env.minio.example ↔ validate-env schema drift guard
@@ -195,7 +195,7 @@ co-locate specs under `src` and were already covered). This closed the
 grading audit's consensus #1 — the type-level halves of the public-API pins
 (`expectTypeOf`, `@ts-expect-error` negatives) used to be dead in every gate.
 Its first execution surfaced real drift the runtime suites tolerated (specs
-importing types `@upupjs/core/internal` never exported, tests pinning the
+importing types `@useupup/core/internal` never exported, tests pinning the
 retired `enableWorkers`/`appKey` option names, a dead `"link"` source id) —
 treat a red test-tree typecheck as an API-drift signal, not test noise.
 
@@ -224,7 +224,7 @@ from CI. The fix is always `prettier --write`, never `--no-verify`.
 
 Flake protocol: if a test fails only in the full run, re-run it isolated
 before suspecting your change. Known load-sensitive cases:
-`@upupjs/server tests/token-refresh.test.ts` ("refresh success") and
+`@useupup/server tests/token-refresh.test.ts` ("refresh success") and
 `tests/transfer.test.ts` (the 4 MB single-PUT case) can exceed their 5 s
 timeouts when the whole suite runs but pass alone; six-storybook cf boots
 can throw transient Windows `STATUS_STACK_BUFFER_OVERRUN`s.
@@ -304,7 +304,7 @@ source of truth. After an intentional UI change:
 
 1. Set `UPDATE_PARITY=1` and run the parity spec against React only, invoking
    Playwright directly so the `--project` flag lands in flag position:
-   `pnpm exec dotenv -e local-dev/.env.minio -- pnpm --filter @upupjs/e2e-test exec playwright test --config playwright.crossframework.config.ts --project react`
+   `pnpm exec dotenv -e local-dev/.env.minio -- pnpm --filter @useupup/e2e-test exec playwright test --config playwright.crossframework.config.ts --project react`
    — fixtures are rewritten from React's DOM. Do NOT use the
    `test:e2e:cf -- --project react` script form: pnpm forwards the literal `--`
    and Playwright reads `--project react` as positional filename filters, so only
@@ -405,7 +405,7 @@ the suites actually drive):
   `CloudProvider`, the `cloudDrives` config, i18n keys) and kebab-case on the
   wire / plugin / DOM (`one-drive` / `google-drive` — plugin ids, server
   provider slugs, event prefixes, `data-upup-slot` / selector strings).
-  `providerSlug()` in `@upupjs/core` `strategies/server-transfer.ts` is the ONE
+  `providerSlug()` in `@useupup/core` `strategies/server-transfer.ts` is the ONE
   camel→kebab mapping boundary. The bare third form `onedrive` is RETIRED in
   every layer — `pnpm run vocab:check` fails on any surviving bare token; the
   sole KEEP is `interactive-example`'s `localAssistant.ts`, which matches
@@ -420,7 +420,7 @@ the suites actually drive):
   reintroduce.
 - One name per function, one function per name: no aliased re-exports, and a
   name means the same thing in every package (`createUpupHandler` = the
-  @upupjs/server core factory; `createUpupNextHandler` = its Next wrapper).
+  @useupup/server core factory; `createUpupNextHandler` = its Next wrapper).
 - The error taxonomy is `UpupError` + its subclasses plus
   `uploadErrorFromResponse` — those `Upload*`-prefixed FUNCTION names stay
   (error domain, not UI vocabulary; only `Adapter*`/`Root*` were retired).
@@ -492,7 +492,7 @@ method carried the §16 rename across the whole monorepo without a regression.
 Choices that look like gaps but are rulings. Re-litigate with the maintainer
 if needed; never silently "improve" them:
 
-- **The image editor is react/preact-only.** `@upupjs/preact` ships the real
+- **The image editor is react/preact-only.** `@useupup/preact` ships the real
   Filerobot editor as a lazily-loaded real-React island (`filerobot-island.js`,
   budgeted separately in `.size-limit.json`); vue/svelte/angular/vanilla
   intentionally stub it. Do not port it to the other frameworks.
@@ -553,9 +553,12 @@ DrivePlugin`. All three popup providers now persist a token-expiry key and refre
 
 ## Git & commits
 
-- Default branch `master`; current integration branch `v2-clean` (the v2 work
-  is intentionally unmerged). Do not merge, PR, or push to `master` without an
-  explicit maintainer decision.
+- `master` is the production / release branch — `publish.yml` runs on push to
+  `master`. `dev` is the integration branch: feature branches PR into `dev`.
+  `dev` is promoted to `master` via a dev→master PR, then `master` is synced
+  back with a master→dev PR. Self-approval is impossible on this repo, so PRs
+  merge with `gh pr merge --merge --admin --delete-branch=false`; both rollup
+  checks (`Status Check`, `E2E Status Check`) must be green first.
 - Conventional commits: `feat:`, `fix(scope):`, `refactor!:` for breaking.
 - **Stage explicit paths only** — never `git add -A` / `.` / `-u`. Never stage
   `dist/`, `test-results/`, `apps/e2e-test/dist/`, or `docs/superpowers/`.
@@ -603,7 +606,7 @@ DrivePlugin`. All three popup providers now persist a token-expiry key and refre
   publishing: full e2e + real-MinIO suites + the a11y/overflow sweep
   (`pnpm run e2e:a11y` — the axe serious/critical ratchet vs
   `a11y-baseline.json`; runs in NO PR gate), the **Lighthouse** job
-  (`pnpm --filter @upupjs/landing run lighthouse`, config
+  (`pnpm --filter @useupup/landing run lighthouse`, config
   `apps/landing/lighthouserc.cjs`: production `next build`+`start`, asserts
   SEO=100 on every audited page and Best Practices 100 on docs pages /
   ratcheted ~0.74 on home+framework pages whose StackBlitz embed + ads tag set
@@ -621,7 +624,7 @@ DrivePlugin`. All three popup providers now persist a token-expiry key and refre
   the suite, whole-job `::notice` if none set); a configured-but-broken token →
   RED. That same job also boots MinIO and runs a Playwright HTTP-surface layer
   (`apps/e2e-test/drive-sandbox/server-transfer.spec.ts`) proving the same
-  sandbox creds for all four providers through `@upupjs/server`'s route dispatch →
+  sandbox creds for all four providers through `@useupup/server`'s route dispatch →
   drive auth → drive→S3 transfer into a real bucket, under the same per-provider
   skip-green/red gating. That HTTP-surface layer also proves the >5 MiB
   streaming-multipart path (no incomplete upload left behind), the policy


### PR DESCRIPTION
Three unrelated hygiene fixes found after the 3.3.0 release. No behavior change in any workflow.

## 1. Pin the remaining GitHub Actions to commit SHAs

A pre-existing security-review notice flagged mutable action tags. Every `uses:` across `.github/workflows` is now a 40-char commit SHA with the resolved version in a trailing comment.

| action | was | now |
| --- | --- | --- |
| `actions/upload-artifact` (main, e2e, nightly) | `@v4` | `ea165f8d…` `# v4.6.2` |
| `actions/checkout` (publish-sdk) | `@v7` | `3d3c42e5…` `# v7.0.1` |
| `actions/setup-node` (publish-sdk) | `@v7` | `820762786…` `# v7.0.0` |

`upload-artifact@v4` currently resolves to the same commit as `v4.6.2`, so this is behaviorally a no-op; it just stops the tag moving under us. Already-pinned actions are untouched, as is `changesets/action` at `v1.9.0` (its major is coupled to the Changesets CLI major). Dependabot already tracks CI action pins, so nothing else changes.

`publish-sdk.yml` also picks up a whole-file prettier reformat: it was committed with 2-space indentation against this repo's 4-space prettier config and has been failing `prettier --check` since it landed. CI never caught it (prettier-check is scoped to `packages/*/src`); staging it for the pin put it in front of lint-staged, which does check it.

## 2. `publish.yml` — the trusted-publisher note is now a precondition, not a status report

The old comment asserted every `@useupup` package already had its npm trusted publisher configured, dated 2026-08-01. That was false for `@useupup/server` until today, and a dated "already done" note decays as soon as a package is added or a scope moves.

It now states the standing rule: publishing is OIDC-only; every `@useupup` package must have a trusted publisher (GitHub Actions, `DevinoSolutions/upup`, workflow `publish.yml`); a package without one fails its own publish and therefore the job, but its version number is **not** burned, so the fix is to add the publisher and re-run; verify each package's npm access page before merging a Version Packages PR. The npm-upgrade-after-`setup-node` ordering note is preserved.

## 3. `CLAUDE.md` — scope sweep and the real branch model

- The npm scope moved to `@useupup` on 2026-09-02, but the guide still named `@upupjs/*` in 34 places. Swept with an exact-substring codemod over every line outside the Naming-vocabulary scope-history bullet, which deliberately narrates the `@upupjs` era and is preserved verbatim. The only surviving `upupjs` tokens are that bullet's three.
- "Git & commits" still called `v2-clean` the integration branch and forbade touching `master`. Replaced with the model in use: `master` is production/release (`publish.yml` runs on push to master), `dev` is integration, feature branches PR into `dev`, `dev` is promoted via a dev→master PR and `master` synced back with a master→dev PR, PRs merge with `--admin` because self-approval is impossible here, and both rollup checks must be green.

The rest of that section (conventional commits, explicit staging, `docs/superpowers`, the hooks) is unchanged.

## Possibly stale, not touched

Flagging for a maintainer decision rather than editing:

1. **`pnpm/action-setup` pin comments are wrong in every workflow.** All 14 occurrences read `@0977fd99…  # v4.4.0`, but that SHA is `v6.0.10`; `v4.4.0` is `fc06bc12…`. The SHA is what actually runs, so CI is on pnpm action v6 while the comment claims v4. Left alone because the brief said not to touch already-pinned actions, and correcting the comment would surface a major-version jump someone should confirm was intended.
2. **`CLAUDE.md` gate line claims lint covers "3 apps (playground, landing, docs)".** There is no `apps/docs` (the guide itself says the standalone docs app is gone) and only `@useupup/landing` and `@useupup/playground` have a `lint` script. Should read 2 apps.
3. **`sdk/` and `publish-sdk.yml` are undocumented.** `sdk/package.json` is `@useupup/sdk@0.0.1` and not private, with its own manual publish workflow, but the package map lists only the nine `@useupup/*` packages and the CI section lists only main/e2e/nightly/publish. Relatedly, `publish-sdk.yml`'s own header comment says "this repo's own release flow publishes the root `upup` package", but the root `package.json` is `private: true`.

## Verification

- `prettier --check` on all six touched files: exit 0 (confirmed twice, bash and PowerShell `$LASTEXITCODE`).
- `pnpm run vocab:check`: exit 0, 1400 tracked files clean of 15 retired tokens.
- Pre-commit hooks ran on all three commits (core/react/server unit suites green); pre-push ran typecheck + lint + knip.
