### PR TITLE
fix(core): hide default capture sources that can never satisfy allowedFileTypes

### DIFF
--- a/.changeset/hide-impossible-capture-sources.md
+++ b/.changeset/hide-impossible-capture-sources.md
@@ -1,0 +1,20 @@
+---
+'@useupup/core': patch
+---
+
+The default source set no longer shows capture sources whose output can never
+satisfy `allowedFileTypes` (#340).
+
+`allowedFileTypes: 'application/pdf'` used to leave the camera, microphone and
+screen chips in place, and every recording they produced was rejected the moment
+it was added. `normalizeUploaderOptions` now drops a default capture source when
+no entry in the resolved accept list could match anything that source can emit —
+camera emits `image/jpeg` (with `image/png` as the `toDataURL` fallback),
+microphone `audio/webm` / `audio/ogg` / `audio/mp4`, screen `video/webm` /
+`video/mp4`, all read off the code that builds the `File`.
+
+The match fails open: a wildcard, an unrecognized extension, or anything that is
+neither a MIME type nor an extension keeps every source. `local` and `url` are
+never filtered, cloud drives are untouched, and an explicitly passed `sources`
+array is always honored verbatim. A dropped source logs one dev-only
+`console.warn` naming the source and the accept list.

--- a/packages/core/src/__tests__/uploader/capture-source-filter.test.ts
+++ b/packages/core/src/__tests__/uploader/capture-source-filter.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { normalizeUploaderOptions } from '../../uploader/normalize-options'
+import { FileSource } from '../../types/file-source'
+import { DEFAULT_SOURCES } from '../../orchestrator/helpers'
+
+/**
+ * #340: the DEFAULT source set hides capture sources whose output can never
+ * satisfy `allowedFileTypes`. Driven through `normalizeUploaderOptions` — the
+ * real wiring point every framework inherits.
+ */
+function sourcesFor(
+    allowedFileTypes?: string,
+    sources?: FileSource[],
+): FileSource[] {
+    return normalizeUploaderOptions({
+        ...(allowedFileTypes === undefined ? {} : { allowedFileTypes }),
+        ...(sources === undefined ? {} : { sources }),
+    }).resolved.sources
+}
+
+describe('default capture-source filtering (#340)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('keeps the whole default set when allowedFileTypes is absent', () => {
+        expect(sourcesFor()).toEqual(DEFAULT_SOURCES)
+    })
+
+    it('keeps the whole default set for the match-all accept values', () => {
+        for (const accept of ['*', '*/*']) {
+            expect(sourcesFor(accept)).toEqual(DEFAULT_SOURCES)
+        }
+    })
+
+    it('drops camera/microphone/screen for a document-only accept list', () => {
+        expect(sourcesFor('application/pdf')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+        ])
+    })
+
+    it('keeps camera and screen but drops microphone for image/* + video/*', () => {
+        expect(sourcesFor('image/*,video/*')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.CAMERA,
+            FileSource.SCREEN,
+        ])
+    })
+
+    it('image/* keeps camera only', () => {
+        expect(sourcesFor('image/*')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.CAMERA,
+        ])
+    })
+
+    it('audio/* keeps microphone only', () => {
+        expect(sourcesFor('audio/*')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.MICROPHONE,
+        ])
+    })
+
+    it('video/* keeps screen only', () => {
+        expect(sourcesFor('video/*')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.SCREEN,
+        ])
+    })
+
+    it('an exact capture MIME keeps exactly its source', () => {
+        expect(sourcesFor('video/webm')).toContain(FileSource.SCREEN)
+        expect(sourcesFor('video/webm')).not.toContain(FileSource.CAMERA)
+        expect(sourcesFor('audio/webm')).toContain(FileSource.MICROPHONE)
+        expect(sourcesFor('image/jpeg')).toContain(FileSource.CAMERA)
+    })
+
+    it('an exact image MIME the camera never emits drops camera', () => {
+        expect(sourcesFor('image/svg+xml')).not.toContain(FileSource.CAMERA)
+    })
+
+    it('never filters local or url', () => {
+        const kept = sourcesFor('application/pdf')
+        expect(kept).toContain(FileSource.LOCAL)
+        expect(kept).toContain(FileSource.URL)
+    })
+
+    it('never filters an explicitly passed sources array', () => {
+        expect(
+            sourcesFor('application/pdf', [
+                FileSource.CAMERA,
+                FileSource.MICROPHONE,
+                FileSource.SCREEN,
+            ]),
+        ).toEqual([FileSource.CAMERA, FileSource.MICROPHONE, FileSource.SCREEN])
+    })
+
+    it('classified extension-only list: .pdf drops all three capture sources', () => {
+        expect(sourcesFor('.pdf')).toEqual([FileSource.LOCAL, FileSource.URL])
+    })
+
+    it('classified extension-only list: .jpg keeps camera', () => {
+        expect(sourcesFor('.jpg')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.CAMERA,
+        ])
+    })
+
+    it('extensions match at top-level-type granularity, so .webm keeps microphone and screen', () => {
+        expect(sourcesFor('.webm')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+            FileSource.MICROPHONE,
+            FileSource.SCREEN,
+        ])
+    })
+
+    it('fails open: one unclassifiable extension keeps everything', () => {
+        expect(sourcesFor('.pdf,.zzz-not-a-real-extension')).toEqual(
+            DEFAULT_SOURCES,
+        )
+    })
+
+    it('fails open on an accept entry that is neither a MIME nor an extension', () => {
+        expect(sourcesFor('pdf')).toEqual(DEFAULT_SOURCES)
+    })
+
+    it('an accept preset name resolves first, then filters (documents drops capture)', () => {
+        expect(sourcesFor('documents')).toEqual([
+            FileSource.LOCAL,
+            FileSource.URL,
+        ])
+    })
+
+    it('an extension-only accept preset still filters instead of failing open', () => {
+        expect(sourcesFor('3d')).toEqual([FileSource.LOCAL, FileSource.URL])
+    })
+
+    it('warns once per dropped source in dev', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        sourcesFor('application/pdf')
+        expect(warn).toHaveBeenCalledTimes(3)
+        const messages = warn.mock.calls.map(call => String(call[0]))
+        expect(messages.some(m => m.includes('"camera"'))).toBe(true)
+        expect(messages.some(m => m.includes('"microphone"'))).toBe(true)
+        expect(messages.some(m => m.includes('"screen"'))).toBe(true)
+        expect(messages[0]).toContain('application/pdf')
+    })
+
+    it('does not warn when nothing is dropped', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        sourcesFor('*')
+        expect(warn).not.toHaveBeenCalled()
+    })
+})

--- a/packages/core/src/uploader/capture-source-filter.ts
+++ b/packages/core/src/uploader/capture-source-filter.ts
@@ -1,0 +1,240 @@
+import { FileSource } from '../types/file-source'
+import { ACCEPT_PRESETS } from '../utils/accept-presets'
+
+/**
+ * Hides DEFAULT capture sources whose output can never satisfy the configured
+ * accept list (#340). A host that sets `allowedFileTypes: 'application/pdf'`
+ * still got camera/microphone/screen chips in the default source set, and every
+ * recording they produced was rejected on add.
+ *
+ * Two hard rules:
+ *  - Only the DEFAULT set is filtered. An explicit `sources` array is always
+ *    honored verbatim.
+ *  - `local` and `url` are never filtered (their output is host-chosen, not
+ *    produced by us), and cloud drives are unaffected.
+ *
+ * The matcher FAILS OPEN: a source is dropped only when we can prove no accept
+ * entry could ever match one of its outputs.
+ */
+
+type MediaFamily = 'image' | 'audio' | 'video'
+
+/**
+ * The MIME types each capture source can actually emit, derived from the code
+ * that builds the File — not from guesses:
+ *
+ *  - `camera` → `image/jpeg`. React passes `screenshotFormat="image/jpeg"` to
+ *    react-webcam; vue/svelte/angular/vanilla all call
+ *    `canvas.toDataURL('image/jpeg')` and stamp `type: 'image/jpeg'`. No camera
+ *    path records video. `image/png` is included because `toDataURL` falls back
+ *    to PNG when the requested format is unsupported (HTML spec).
+ *  - `microphone` → `new MediaRecorder(stream)` with no `mimeType`, read back as
+ *    `recorder.mimeType || 'audio/webm'`: webm on Chromium/Firefox, mp4 on
+ *    Safari, and React's own filename branch also admits `.ogg`.
+ *  - `screen` → `new MediaRecorder(displayStream)` read back as
+ *    `recorder.mimeType || 'video/webm'`: webm on Chromium/Firefox, mp4 on
+ *    Safari. The screen source has no still-image path.
+ */
+const CAPTURE_SOURCE_OUTPUT_MIMES: Partial<
+    Record<FileSource, readonly string[]>
+> = {
+    [FileSource.CAMERA]: ['image/jpeg', 'image/png'],
+    [FileSource.MICROPHONE]: ['audio/webm', 'audio/ogg', 'audio/mp4'],
+    [FileSource.SCREEN]: ['video/webm', 'video/mp4'],
+}
+
+/**
+ * Extensions we can classify into media families. An extension is a weaker
+ * signal than a MIME type (one container holds several codecs), so extension
+ * entries are matched at top-level-type granularity, never on the subtype.
+ */
+const MEDIA_EXTENSION_FAMILIES: Record<string, readonly MediaFamily[]> = {
+    '.jpg': ['image'],
+    '.jpeg': ['image'],
+    '.jfif': ['image'],
+    '.png': ['image'],
+    '.apng': ['image'],
+    '.webp': ['image'],
+    '.gif': ['image'],
+    '.bmp': ['image'],
+    '.tif': ['image'],
+    '.tiff': ['image'],
+    '.heic': ['image'],
+    '.heif': ['image'],
+    '.avif': ['image'],
+    '.svg': ['image'],
+    '.cr2': ['image'],
+    '.cr3': ['image'],
+    '.nef': ['image'],
+    '.arw': ['image'],
+    '.dng': ['image'],
+    '.orf': ['image'],
+    '.rw2': ['image'],
+    '.raf': ['image'],
+    '.raw': ['image'],
+    '.mp3': ['audio'],
+    '.wav': ['audio'],
+    '.m4a': ['audio'],
+    '.aac': ['audio'],
+    '.flac': ['audio'],
+    '.oga': ['audio'],
+    '.opus': ['audio'],
+    '.weba': ['audio'],
+    '.mov': ['video'],
+    '.mkv': ['video'],
+    '.avi': ['video'],
+    '.m4v': ['video'],
+    '.mpg': ['video'],
+    '.mpeg': ['video'],
+    '.ogv': ['video'],
+    // Ambiguous containers: both an audio-only and a video track are legal.
+    '.webm': ['audio', 'video'],
+    '.mp4': ['audio', 'video'],
+    '.ogg': ['audio', 'video'],
+    '.3gp': ['audio', 'video'],
+}
+
+/**
+ * Extensions we know are NOT capture output. Every extension any accept preset
+ * mentions counts as known (so `allowedFileTypes: '3d'` or `'code'` filters
+ * instead of failing open), plus the everyday document/archive extensions the
+ * presets happen to express as MIME types.
+ */
+const KNOWN_NON_MEDIA_EXTENSIONS: ReadonlySet<string> = new Set([
+    ...Object.values(ACCEPT_PRESETS)
+        .flatMap(preset => preset.accept.split(','))
+        .map(token => token.trim().toLowerCase())
+        .filter(token => token.startsWith('.')),
+    '.pdf',
+    '.doc',
+    '.docx',
+    '.odt',
+    '.xls',
+    '.xlsx',
+    '.ods',
+    '.ppt',
+    '.pptx',
+    '.odp',
+    '.txt',
+    '.rtf',
+    '.csv',
+    '.json',
+    '.xml',
+    '.html',
+    '.htm',
+    '.css',
+    '.js',
+    '.mjs',
+    '.cjs',
+    '.zip',
+    '.rar',
+    '.7z',
+    '.tar',
+    '.gz',
+    '.epub',
+])
+
+type AcceptEntry =
+    | { kind: 'any' }
+    | { kind: 'mime'; value: string }
+    | { kind: 'wildcard'; prefix: string }
+    | { kind: 'extension'; families: readonly MediaFamily[] }
+    | { kind: 'unknown' }
+
+function classifyAcceptEntry(raw: string): AcceptEntry {
+    const entry = raw.trim().toLowerCase()
+    if (entry === '*' || entry === '*/*' || entry === '*.*')
+        return { kind: 'any' }
+    if (entry.endsWith('/*'))
+        return { kind: 'wildcard', prefix: entry.slice(0, -1) }
+    if (entry.startsWith('.')) {
+        const families = MEDIA_EXTENSION_FAMILIES[entry]
+        if (families) return { kind: 'extension', families }
+        if (KNOWN_NON_MEDIA_EXTENSIONS.has(entry))
+            return { kind: 'extension', families: [] }
+        return { kind: 'unknown' }
+    }
+    if (entry.includes('/')) return { kind: 'mime', value: entry }
+    return { kind: 'unknown' }
+}
+
+function familyOf(mime: string): MediaFamily | undefined {
+    const top = mime.split('/')[0]
+    return top === 'image' || top === 'audio' || top === 'video'
+        ? top
+        : undefined
+}
+
+function couldMatch(
+    entry: AcceptEntry,
+    outputMimes: readonly string[],
+): boolean {
+    switch (entry.kind) {
+        case 'any':
+        case 'unknown':
+            return true
+        case 'mime':
+            return outputMimes.includes(entry.value)
+        case 'wildcard':
+            return outputMimes.some(mime => mime.startsWith(entry.prefix))
+        case 'extension':
+            return outputMimes.some(mime => {
+                const family = familyOf(mime)
+                return family !== undefined && entry.families.includes(family)
+            })
+    }
+}
+
+/**
+ * Returns `sources` with every capture source whose declared output can never
+ * satisfy `accept` removed. Call it ONLY for the default source set.
+ */
+export function filterDefaultCaptureSources(
+    sources: readonly FileSource[],
+    accept: string,
+): FileSource[] {
+    const entries = accept
+        .split(',')
+        .map(token => token.trim())
+        .filter(Boolean)
+        .map(classifyAcceptEntry)
+
+    // No constraint at all, or an entry we cannot reason about anywhere in the
+    // list: never hide a source we cannot prove useless.
+    if (entries.length === 0 || entries.some(entry => entry.kind === 'any'))
+        return [...sources]
+    if (entries.some(entry => entry.kind === 'unknown')) return [...sources]
+
+    const kept: FileSource[] = []
+    const dropped: FileSource[] = []
+    for (const source of sources) {
+        const outputMimes = CAPTURE_SOURCE_OUTPUT_MIMES[source]
+        if (!outputMimes) {
+            kept.push(source)
+            continue
+        }
+        if (entries.some(entry => couldMatch(entry, outputMimes))) {
+            kept.push(source)
+        } else {
+            dropped.push(source)
+        }
+    }
+
+    if (
+        dropped.length > 0 &&
+        typeof process !== 'undefined' &&
+        process.env.NODE_ENV !== 'production'
+    ) {
+        for (const source of dropped) {
+            console.warn(
+                `[upup] hiding the default "${source}" source: nothing it can produce (${(
+                    CAPTURE_SOURCE_OUTPUT_MIMES[source] ?? []
+                ).join(
+                    ', ',
+                )}) matches allowedFileTypes "${accept}". Pass an explicit \`sources\` array to keep it.`,
+            )
+        }
+    }
+
+    return kept
+}

--- a/packages/core/src/uploader/normalize-options.ts
+++ b/packages/core/src/uploader/normalize-options.ts
@@ -5,6 +5,7 @@ import {
     getDir,
 } from '../orchestrator/helpers'
 import { resolveAccept } from '../utils/accept-presets'
+import { filterDefaultCaptureSources } from './capture-source-filter'
 import { createTranslator } from '../i18n/create-translator'
 import { enUS } from '../i18n/locales/en-US'
 import { resolveLocaleBundle } from '../i18n/resolve-locale'
@@ -29,19 +30,21 @@ export function normalizeUploaderOptions(
         (options.allowedFileTypes as string | string[] | undefined) ?? '*'
     const mini = options.mini ?? false
     const animations = options.animations ?? true
+    const accept = resolveAccept(
+        typeof acceptProp === 'string' ? acceptProp : acceptProp.join(','),
+    )
+    // #340: an EXPLICIT sources array is honored verbatim; the DEFAULT set drops
+    // capture sources whose output can never satisfy `accept`.
     const resolvedSources = options.sources
         ? (options.sources
               .map(s => normalizeSource(s))
               .filter(Boolean) as FileSource[])
-        : DEFAULT_SOURCES
+        : filterDefaultCaptureSources(DEFAULT_SOURCES, accept)
     const resolvedLimit = options.maxFiles ?? 10
     const resolvedMode =
         options.mode ??
         (options.serverUrl && !options.uploadEndpoint ? 'server' : 'client')
     const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
-    const accept = resolveAccept(
-        typeof acceptProp === 'string' ? acceptProp : acceptProp.join(','),
-    )
     const limit = mini ? 1 : Math.max(resolvedLimit, 1)
     const multiple = mini ? false : limit > 1
     const folderUploadAllowDrop = options.folderUpload?.allowDrop ?? false


### PR DESCRIPTION
## Summary

Suggestion 2 from #340: the DEFAULT source set no longer shows a capture source whose output can never satisfy the configured `allowedFileTypes`. Previously `allowedFileTypes="application/pdf"` still rendered the camera, microphone and screen chips, and every recording they produced was rejected the moment it was added.

One place changes — `normalizeUploaderOptions` (`packages/core/src/uploader/normalize-options.ts`) — so all six frameworks inherit it. `accept` is now resolved before `sources`, and the default set passes through the new `filterDefaultCaptureSources` (`packages/core/src/uploader/capture-source-filter.ts`). `DEFAULT_SOURCES` is unchanged, no new event, no new public or `/internal` export.

## Derived output-MIME table

Read off the code that builds the `File`, not guessed:

| source | output MIMEs | derived from |
| --- | --- | --- |
| `camera` | `image/jpeg`, `image/png` | React passes `screenshotFormat="image/jpeg"` to react-webcam (`packages/react/src/components/CameraUploader.tsx:61`); vue/svelte/angular/vanilla all call `canvas.toDataURL('image/jpeg')` and stamp `type: 'image/jpeg'` (`packages/vue/src/composables/useCameraUploader.ts:93,108`, `packages/svelte/src/composables/useCameraUploader.ts:108,124`, `packages/angular/src/services/camera-uploader.service.ts:87,103`, `packages/vanilla/src/controllers/camera.ts:98,113`). No camera path records video. `image/png` is included because `toDataURL` falls back to PNG when the requested format is unsupported (HTML spec). |
| `microphone` | `audio/webm`, `audio/ogg`, `audio/mp4` | `new MediaRecorder(stream)` with no `mimeType`, read back as `recorder.mimeType \|\| 'audio/webm'` (`packages/react/src/components/AudioUploader.tsx:45,54` and the vue/svelte/angular/vanilla twins) — webm on Chromium/Firefox, mp4 on Safari; React's own filename branch also admits `.ogg`. |
| `screen` | `video/webm`, `video/mp4` | `new MediaRecorder(displayStream)` read back as `recorder.mimeType \|\| 'video/webm'` (`packages/react/src/components/ScreenCaptureUploader.tsx:70,79` and its twins). The screen source has no still-image path, so no `image/*`. |

`local` and `url` are never filtered (their output is host-chosen), and cloud drives are untouched.

## Fail-open rule

A source is dropped only when we can prove nothing it emits could match. Every ambiguity keeps it:

- Empty accept list, `*`, `*/*` → keep everything.
- Exact MIME → must equal one of the source's outputs. `type/*` → must prefix one of them.
- Extension entries are matched at top-level-type granularity only (`image` / `audio` / `video`), never on the subtype, because one container holds several codecs. `.webm` / `.mp4` / `.ogg` / `.3gp` count as both audio and video.
- An extension we cannot classify anywhere in the list disables filtering entirely — the whole default set is kept. "Known" means either a media extension or an extension that appears in any `ACCEPT_PRESETS` entry, plus the everyday document/archive extensions the presets express as MIME types. So `allowedFileTypes: '3d'` (all extensions) filters instead of silently failing open, while `.some-proprietary-ext` keeps every source.
- An entry that is neither a MIME type nor an extension (e.g. a bare `pdf`) is treated as unclassifiable → keep everything.

An explicitly passed `sources` array is never filtered, under any accept list.

## Discoverability

Each dropped source logs exactly one `console.warn` behind the existing core dev guard (`typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'`, the same shape as `packages/core/src/core.ts:485`), naming the source, its output MIMEs, the accept list, and the `sources` escape hatch.

## Tests

`packages/core/src/__tests__/uploader/capture-source-filter.test.ts`, 20 cases, all driven through `normalizeUploaderOptions`:

- default set kept when `allowedFileTypes` is absent, and for `*` / `*/*`
- `application/pdf` drops camera/microphone/screen, keeps local/url
- `image/*,video/*` keeps camera+screen, drops microphone; `image/*`, `audio/*`, `video/*` each keep exactly their source
- exact capture MIMEs (`image/jpeg`, `audio/webm`, `video/webm`) keep their source; `image/svg+xml` drops camera
- `local` / `url` never filtered; an explicit `sources` array never filtered
- extension-only lists: `.pdf` drops all three, `.jpg` keeps camera, `.webm` keeps microphone+screen
- fail-open: one unclassifiable extension, and a bare non-MIME token, each keep the whole default set
- preset names resolve first then filter: `documents` and `3d` both drop all three
- the dev warning fires once per dropped source and not at all when nothing is dropped

Gates run green locally: `@useupup/core` test (144 files / 1761 tests), core build, `@useupup/react` test (71 / 644), core `typecheck` (base + `tsconfig.test.json`), core `lint`, `prettier --check` on the four touched paths. The pre-commit hook's core/react/server suites and the pre-push `typecheck` + `turbo lint` + `knip` all passed. `tests/public-api.test.ts` and `tests/internal-surface.test.ts` are untouched — no surface was added.

## On the 2026-08-11 estimate

The triage comment budgeted a parity-fixture regen plus a full six-framework run. That does not apply: all three parity stories (`Parity` → `default`, `ParityHero` → `hero`, `ParityCrowded` → `crowded`) pass `sources` explicitly and none of them sets `allowedFileTypes`, so `parity-fixtures.json` cannot move. Same for the storybook state story `restrictedFileRejected`, which pairs `allowedFileTypes: 'application/pdf'` with `sources: ['local']`.

Two non-parity places do shift their chip row, both intentionally and neither asserted on:

- `apps/storybook-react/src/stories/Limits.stories.tsx` `PdfOnly` (and `ImagesOnly`) — no test references them.
- `apps/e2e-test/src/main.tsx` `RestrictionsDemo` (`allowedFileTypes="image/*"`) now shows local/url/camera; `apps/e2e-test/e2e/restrictions.spec.ts` makes no chip assertions. The snapvisor restrictions screenshot will show the change as a reviewable image diff — no golden is committed, so nothing fails.

Closes #340
