### PR TITLE
fix(core): host error message slot and EXIF-skip signal (#367 items 2, 4)

### DIFF
--- a/.changeset/host-error-message-and-exif-skip-signal.md
+++ b/.changeset/host-error-message-and-exif-skip-signal.md
@@ -1,0 +1,28 @@
+---
+'@useupup/core': patch
+'@useupup/react': patch
+'@useupup/vue': patch
+'@useupup/svelte': patch
+'@useupup/angular': patch
+'@useupup/vanilla': patch
+---
+
+The default panel now shows your error message next to the machine code, and a
+skipped EXIF strip leaves a marker on the file (#367 items 2 and 4).
+
+A failure carrying a code used to render as `uploadFailedWithCode`, which
+interpolated the code and nothing else — so an endpoint that returned a useful
+sentence watched it disappear between `onError` and the panel. The key now has a
+second `{message}` slot carrying the error's own message, added to all nine
+locale bundles so translators control placement (override the key to reorder the
+slots, drop the code, or show only your own wording). All six framework panels
+pass both values, and the message is rendered as text, never as markup.
+
+`stripExifData` skips animated GIF/WebP/APNG because canvas has no animated
+encoder, which means an animated WebP or APNG reaches storage with the EXIF you
+asked to remove. The `exif` step now records that on the file:
+`metadata.metadataStripSkipped === true` with
+`metadata.metadataStripSkippedReason === 'animated-image'`. A file whose EXIF
+really was stripped carries `exifStripped: true` and no marker, and
+`imageCompression` skipping an animated image does not set it — nothing was asked
+to be removed. No new event, no new option.

--- a/apps/landing/content/docs/api-reference/error-codes.mdx
+++ b/apps/landing/content/docs/api-reference/error-codes.mdx
@@ -35,7 +35,7 @@ below for what actually drives automatic retries.
 
 | Code                     | Meaning                                             | Typical trigger                                                                                                                                                                                                                                                                                                                                                     | Retryable       |
 | ------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `AUTH_REQUIRED`          | Anonymous uploads are disabled                      | `@useupup/server` `/presign` or `/multipart/init` reached with no `auth`, no `getUserId`, and no `allowAnonymousUploads` — returns 403                                                                                                                                                                                                                               | no              |
+| `AUTH_REQUIRED`          | Anonymous uploads are disabled                      | `@useupup/server` `/presign` or `/multipart/init` reached with no `auth`, no `getUserId`, and no `allowAnonymousUploads` — returns 403                                                                                                                                                                                                                              | no              |
 | `AUTH_DENIED`            | The upload token belongs to a different user        | A multipart continuation route (sign-part / complete / abort / resume) called with a token whose `uid` is not the current user — returns 403                                                                                                                                                                                                                        | no              |
 | `AUTH_EXPIRED`           | A stored drive credential is dead or revoked        | The server's drive-token refresh call is rejected by the provider; the stored tokens are deleted and the user must re-authorize. Surfaces only through the server's `onError` reporter — it is never returned as a response-body code                                                                                                                               | no              |
 | `AUTH_PROVIDER_ERROR`    | A cloud-drive OAuth or provider call failed         | OAuth code-for-token exchange returns non-2xx (server answers 502). Also the code every `UpupAuthError` carries by construction                                                                                                                                                                                                                                     | no              |
@@ -58,7 +58,7 @@ below for what actually drives automatic retries.
 | `QUOTA_EXCEEDED`         | A configured storage quota is exhausted             | The code every `UpupQuotaError` carries by construction                                                                                                                                                                                                                                                                                                             | no              |
 | `NO_UPLOAD_TARGET`       | No upload destination is configured                 | The default code for `UpupConfigError` — no `uploadEndpoint` / provider wiring to upload to                                                                                                                                                                                                                                                                         | no              |
 | `BAD_REQUEST`            | The request or API call is malformed                | Server-side: an unparseable JSON body or invalid file metadata (400). Client-side: calling `addFiles` / `setFiles` / `upload` / `resume` / `retry` after `destroy()`, or passing an unknown file ID to `replaceFile` / `reorderFiles`                                                                                                                               | no              |
-| `NOT_FOUND`              | The addressed resource is gone server-side          | `@useupup/server` `/multipart/resume` asked to re-attach to a multipart upload the storage provider no longer has — completed, aborted, or reaped by an `AbortIncompleteMultipartUpload` lifecycle rule — returns 404. Deliberately a 4xx: the client drops its saved session and starts a fresh upload rather than retrying something that cannot return            | no              |
+| `NOT_FOUND`              | The addressed resource is gone server-side          | `@useupup/server` `/multipart/resume` asked to re-attach to a multipart upload the storage provider no longer has — completed, aborted, or reaped by an `AbortIncompleteMultipartUpload` lifecycle rule — returns 404. Deliberately a 4xx: the client drops its saved session and starts a fresh upload rather than retrying something that cannot return           | no              |
 
 Codes marked _reserved_ are part of the published enum and safe to reference in
 your own `switch` statements — they simply have no emitter in upup today.
@@ -313,10 +313,14 @@ codes (`expired`, `bad_signature`, `malformed`), S3 provider codes
 `InvalidBucketName`), and the drive controller's `UNAUTHENTICATED`.
 
 Everything else — the other 16 enum members included — falls through to the
-`uploadFailedWithCode` message, and **that message interpolates the raw code**
-(`Upload failed with error code: {code}`). So an unmapped code _is_ shown to the
-end user. Only a completely absent code is code-free, falling back to the plain
-`uploadFailed` message. If you surface codes that matter to your users, either
-map them to your own copy or override `uploadFailedWithCode` for your locale.
+`uploadFailedWithCode` message, and **that message interpolates the raw code
+together with your own error sentence**
+(`Upload failed with error code {code}: {message}`). So an unmapped code _is_
+shown to the end user, and so is whatever `error`/`message` your endpoint
+returned. Only a completely absent code is code-free, falling back to the plain
+`uploadFailed` message. Both slots are optional for a translator: override
+`uploadFailedWithCode` for your locale to reorder them, drop the code, or show
+only your own wording. The interpolated value is always rendered as text, never
+as markup.
 
 See [Localization](/docs/localization/) for overriding those strings per locale.

--- a/apps/landing/content/docs/guides/file-processing.mdx
+++ b/apps/landing/content/docs/guides/file-processing.mdx
@@ -131,6 +131,31 @@ you want compression anyway, that is the cost of the privacy guarantee; if you
 only care about metadata, `stripExifData` alone is enough. Stripped files are
 marked with `exifStripped: true`, alongside `originalSize` and `processedSize`.
 
+### Detecting a skipped strip
+
+The skip above is silent in the upload itself, which matters when the point of
+`stripExifData` is a privacy guarantee — animated WebP and APNG both carry EXIF,
+so those files reach your storage with the metadata you asked to remove. The
+file records it:
+
+```tsx
+<UpupUploader
+    uploadEndpoint="/api/upload-token"
+    stripExifData
+    onFileUploadComplete={(file, key) => {
+        if (file.metadata.metadataStripSkipped) {
+            // metadataStripSkippedReason === 'animated-image'
+            queueServerSideStrip(key)
+        }
+    }}
+/>
+```
+
+`metadataStripSkipped` is set only by the `exif` step, and only when
+`stripExifData` asked for a strip that did not happen. A file whose EXIF really
+was removed carries `exifStripped: true` and no skip marker. `imageCompression`
+skipping an animated image does not set it — nothing was asked to be removed.
+
 ## Thumbnails
 
 `thumbnailGenerator` produces a small preview alongside each image. Unlike the

--- a/packages/angular/src/components/file-list.component.ts
+++ b/packages/angular/src/components/file-list.component.ts
@@ -579,7 +579,7 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
         const code = this.store.uploadErrorCode()
         const message = this.store.uploadError() ?? ''
         return code
-            ? t(tr.uploadFailedWithCode, { code })
+            ? t(tr.uploadFailedWithCode, { code, message })
             : t(tr.uploadFailed, { message })
     }
 

--- a/packages/angular/src/components/file-list.spec.ts
+++ b/packages/angular/src/components/file-list.spec.ts
@@ -114,7 +114,8 @@ function makeStoreMock(files: Map<string, UploadFile>) {
         clickToPreview: 'Click to preview',
         loading: 'Loading…',
         previewError: 'Error:',
-        uploadFailedWithCode: 'Upload failed with error code: {{code}}',
+        uploadFailedWithCode:
+            'Upload failed with error code {{code}}: {{message}}',
         uploadFailed: 'Upload failed: {{message}}',
         zeroBytes: '0 B',
         bytes: 'B',

--- a/packages/core/src/__tests__/i18n/ui-translations.test.ts
+++ b/packages/core/src/__tests__/i18n/ui-translations.test.ts
@@ -59,6 +59,75 @@ describe('flattenTranslatorToUiTranslations — count-based plurals', () => {
 })
 
 /**
+ * #367 item 2: the code-bearing upload-failure string used to interpolate the
+ * machine code and nothing else, so the host's own sentence never reached the
+ * panel. It now carries BOTH slots and each locale decides where they go — so
+ * the guard is per-bundle, not just en-US.
+ */
+describe('uploadFailedWithCode carries a message slot in every locale', () => {
+    const allBundles = [
+        ['en-US', enUS],
+        ['ar-SA', arSA],
+        ['de-DE', deDE],
+        ['es-ES', esES],
+        ['fr-FR', frFR],
+        ['ja-JP', jaJP],
+        ['ko-KR', koKR],
+        ['zh-CN', zhCN],
+        ['zh-TW', zhTW],
+    ] as const
+
+    it.each(allBundles)('%s bakes both slots', (_code, bundle) => {
+        const tr = flattenTranslatorToUiTranslations(
+            createTranslator({ bundle }),
+        )
+        expect(tr.uploadFailedWithCode).toContain('{{code}}')
+        expect(tr.uploadFailedWithCode).toContain('{{message}}')
+    })
+
+    it.each(allBundles)('%s interpolates both slots', (_code, bundle) => {
+        const tr = flattenTranslatorToUiTranslations(
+            createTranslator({ bundle }),
+        )
+        const rendered = t(tr.uploadFailedWithCode, {
+            code: 'QUOTA_EXCEEDED',
+            message: 'Bucket is full',
+        })
+        expect(rendered).toContain('QUOTA_EXCEEDED')
+        expect(rendered).toContain('Bucket is full')
+        expect(rendered).not.toContain('{{')
+    })
+
+    it('en-US reads naturally with both values filled in', () => {
+        const tr = flattenTranslatorToUiTranslations(
+            createTranslator({ bundle: enUS }),
+        )
+        expect(
+            t(tr.uploadFailedWithCode, {
+                code: 'PRESIGN_FAILED',
+                message: 'Presign request failed: 502 Bad Gateway',
+            }),
+        ).toBe(
+            'Upload failed with error code PRESIGN_FAILED: Presign request failed: 502 Bad Gateway',
+        )
+    })
+
+    it('a host override of the key controls slot placement', () => {
+        const tr = flattenTranslatorToUiTranslations(
+            createTranslator({
+                bundle: enUS,
+                overrides: {
+                    errors: { uploadFailedWithCode: '{message} [{code}]' },
+                },
+            }),
+        )
+        expect(t(tr.uploadFailedWithCode, { code: 'X', message: 'nope' })).toBe(
+            'nope [X]',
+        )
+    })
+})
+
+/**
  * Contract guard across ALL shipped locales. `countPluralOther` assumes the
  * count is the first `\p{Nd}+` run in every count-bearing `_other` form, so it
  * swaps exactly that run for `{{count}}`. A future locale that prefixes a

--- a/packages/core/src/i18n/locales/ar-SA.ts
+++ b/packages/core/src/i18n/locales/ar-SA.ts
@@ -221,7 +221,7 @@ export const arSA: LocaleBundle = {
             signedUrlGenerationFailed:
                 '\u0641\u0634\u0644 \u0625\u0646\u0634\u0627\u0621 \u0631\u0627\u0628\u0637 \u0627\u0644\u0631\u0641\u0639 \u0627\u0644\u0645\u0648\u0642\u0639',
             uploadFailedWithCode:
-                '\u0641\u0634\u0644 \u0627\u0644\u0631\u0641\u0639 \u0628\u0631\u0645\u0632 \u0627\u0644\u062E\u0637\u0623: {code}',
+                '\u0641\u0634\u0644 \u0627\u0644\u0631\u0641\u0639 \u0628\u0631\u0645\u0632 \u0627\u0644\u062E\u0637\u0623 {code}: {message}',
             uploadFailed:
                 '\u0641\u0634\u0644 \u0627\u0644\u0631\u0641\u0639: {message}',
             dropboxSessionExpired:

--- a/packages/core/src/i18n/locales/de-DE.ts
+++ b/packages/core/src/i18n/locales/de-DE.ts
@@ -183,7 +183,7 @@ export const deDE: LocaleBundle = {
             signedUrlGenerationFailed:
                 'Signierte Upload-URL konnte nicht generiert werden',
             uploadFailedWithCode:
-                'Upload fehlgeschlagen mit Fehlercode: {code}',
+                'Upload fehlgeschlagen mit Fehlercode {code}: {message}',
             uploadFailed: 'Upload fehlgeschlagen: {message}',
             dropboxSessionExpired:
                 'Ihre Dropbox-Sitzung ist abgelaufen. Bitte authentifizieren Sie sich erneut.',

--- a/packages/core/src/i18n/locales/en-US.ts
+++ b/packages/core/src/i18n/locales/en-US.ts
@@ -171,7 +171,8 @@ export const enUS: LocaleBundle = {
             invalidFileType: 'File type is not allowed',
             storageQuotaExceeded: 'Storage quota has been exceeded',
             signedUrlGenerationFailed: 'Failed to generate signed upload URL',
-            uploadFailedWithCode: 'Upload failed with error code: {code}',
+            uploadFailedWithCode:
+                'Upload failed with error code {code}: {message}',
             uploadFailed: 'Upload failed: {message}',
             dropboxSessionExpired:
                 'Your Dropbox session has expired. Please re-authenticate to continue.',

--- a/packages/core/src/i18n/locales/es-ES.ts
+++ b/packages/core/src/i18n/locales/es-ES.ts
@@ -182,7 +182,7 @@ export const esES: LocaleBundle = {
             signedUrlGenerationFailed:
                 'Error al generar la URL firmada de subida',
             uploadFailedWithCode:
-                'La subida fall\u00F3 con el c\u00F3digo de error: {code}',
+                'La subida fall\u00F3 con el c\u00F3digo de error {code}: {message}',
             uploadFailed: 'La subida fall\u00F3: {message}',
             dropboxSessionExpired:
                 'Su sesi\u00F3n de Dropbox ha expirado. Por favor, vuelva a autenticarse.',

--- a/packages/core/src/i18n/locales/fr-FR.ts
+++ b/packages/core/src/i18n/locales/fr-FR.ts
@@ -186,7 +186,7 @@ export const frFR: LocaleBundle = {
             signedUrlGenerationFailed:
                 "\u00C9chec de la g\u00E9n\u00E9ration de l'URL sign\u00E9e",
             uploadFailedWithCode:
-                "\u00C9chec du t\u00E9l\u00E9versement avec le code d'erreur : {code}",
+                "\u00C9chec du t\u00E9l\u00E9versement avec le code d'erreur {code} : {message}",
             uploadFailed: '\u00C9chec du t\u00E9l\u00E9versement : {message}',
             dropboxSessionExpired:
                 'Votre session Dropbox a expir\u00E9. Veuillez vous r\u00E9authentifier.',

--- a/packages/core/src/i18n/locales/ja-JP.ts
+++ b/packages/core/src/i18n/locales/ja-JP.ts
@@ -199,7 +199,7 @@ export const jaJP: LocaleBundle = {
             signedUrlGenerationFailed:
                 '\u7F72\u540D\u4ED8\u304D\u30A2\u30C3\u30D7\u30ED\u30FC\u30C9URL\u306E\u751F\u6210\u306B\u5931\u6557\u3057\u307E\u3057\u305F',
             uploadFailedWithCode:
-                '\u30A8\u30E9\u30FC\u30B3\u30FC\u30C9\u3067\u30A2\u30C3\u30D7\u30ED\u30FC\u30C9\u306B\u5931\u6557\u3057\u307E\u3057\u305F\uFF1A{code}',
+                '\u30A8\u30E9\u30FC\u30B3\u30FC\u30C9 {code} \u3067\u30A2\u30C3\u30D7\u30ED\u30FC\u30C9\u306B\u5931\u6557\u3057\u307E\u3057\u305F\uFF1A{message}',
             uploadFailed:
                 '\u30A2\u30C3\u30D7\u30ED\u30FC\u30C9\u306B\u5931\u6557\u3057\u307E\u3057\u305F\uFF1A{message}',
             dropboxSessionExpired:

--- a/packages/core/src/i18n/locales/ko-KR.ts
+++ b/packages/core/src/i18n/locales/ko-KR.ts
@@ -154,7 +154,7 @@ export const koKR: LocaleBundle = {
             invalidFileType: '파일 유형이 허용되지 않습니다',
             storageQuotaExceeded: '저장소 할당량을 초과했습니다',
             signedUrlGenerationFailed: '서명된 업로드 URL 생성에 실패했습니다',
-            uploadFailedWithCode: '업로드 실패, 오류 코드: {code}',
+            uploadFailedWithCode: '업로드 실패, 오류 코드 {code}: {message}',
             uploadFailed: '업로드 실패: {message}',
             dropboxSessionExpired:
                 'Dropbox 세션이 만료되었습니다. 계속하려면 다시 인증하세요.',

--- a/packages/core/src/i18n/locales/zh-CN.ts
+++ b/packages/core/src/i18n/locales/zh-CN.ts
@@ -149,7 +149,7 @@ export const zhCN: LocaleBundle = {
             invalidFileType: '文件类型不被允许',
             storageQuotaExceeded: '存储配额已超出',
             signedUrlGenerationFailed: '生成签名上传 URL 失败',
-            uploadFailedWithCode: '上传失败，错误代码：{code}',
+            uploadFailedWithCode: '上传失败，错误代码 {code}：{message}',
             uploadFailed: '上传失败：{message}',
             dropboxSessionExpired:
                 '您的 Dropbox 会话已过期。请重新验证以继续。',

--- a/packages/core/src/i18n/locales/zh-TW.ts
+++ b/packages/core/src/i18n/locales/zh-TW.ts
@@ -149,7 +149,7 @@ export const zhTW: LocaleBundle = {
             invalidFileType: '檔案類型不被允許',
             storageQuotaExceeded: '儲存配額已超出',
             signedUrlGenerationFailed: '生成簽名上傳 URL 失敗',
-            uploadFailedWithCode: '上傳失敗，錯誤代碼：{code}',
+            uploadFailedWithCode: '上傳失敗，錯誤代碼 {code}：{message}',
             uploadFailed: '上傳失敗：{message}',
             dropboxSessionExpired:
                 '您的 Dropbox 會話已過期。請重新驗證以繼續。',

--- a/packages/core/src/i18n/types.ts
+++ b/packages/core/src/i18n/types.ts
@@ -212,7 +212,7 @@ export interface ErrorMessages {
     invalidFileType: string
     storageQuotaExceeded: string
     signedUrlGenerationFailed: string
-    /** ICU: "Upload failed with error code: {code}" */
+    /** ICU: "Upload failed with error code {code}: {message}" */
     uploadFailedWithCode: string
     /** ICU: "Upload failed: {message}" */
     uploadFailed: string

--- a/packages/core/src/i18n/ui-translations.ts
+++ b/packages/core/src/i18n/ui-translations.ts
@@ -356,8 +356,11 @@ export function flattenTranslatorToUiTranslations(
         invalidFileType: tr('errors.invalidFileType'),
         storageQuotaExceeded: tr('errors.storageQuotaExceeded'),
         signedUrlGenerationFailed: tr('errors.signedUrlGenerationFailed'),
+        // Two slots (#367 item 2): the host's own sentence rides along with the
+        // machine code, and each locale decides where it goes.
         uploadFailedWithCode: tr('errors.uploadFailedWithCode', {
             code: '{{code}}',
+            message: '{{message}}',
         }),
         uploadFailed: tr('errors.uploadFailed', { message: '{{message}}' }),
         dropboxSessionExpired: tr('errors.dropboxSessionExpired'),

--- a/packages/core/src/steps/exif.ts
+++ b/packages/core/src/steps/exif.ts
@@ -14,7 +14,21 @@ export function exifStep(): PipelineStep {
             // Stripping EXIF re-encodes through a canvas, and canvas has no
             // animated encoder — an animated GIF/WebP/APNG would come back as
             // its first frame. Leave those alone; the upload is unaffected.
-            if (await isAnimatedImage(file)) return file
+            //
+            // The skip IS observable though: animated WebP and APNG both carry
+            // EXIF, so the file reaches storage with the metadata the host asked
+            // to remove (#367 item 4). Record that on the file rather than
+            // emitting a new event — a privacy-sensitive host reads the marker
+            // off the upload and branches server-side. Same assign-a-new-
+            // metadata-object-onto-the-file shape the thumbnail step uses.
+            if (await isAnimatedImage(file)) {
+                file.metadata = {
+                    ...file.metadata,
+                    metadataStripSkipped: true,
+                    metadataStripSkippedReason: 'animated-image',
+                }
+                return file
+            }
 
             if (context.worker) {
                 try {

--- a/packages/core/src/types/upload-file.ts
+++ b/packages/core/src/types/upload-file.ts
@@ -12,6 +12,16 @@ export type UploadFileMetadata = {
     processedSize?: number
     compressed?: boolean
     exifStripped?: boolean
+    /**
+     * Set when `stripExifData` was requested but deliberately skipped, so the
+     * file reached storage with its original metadata intact. Canvas has no
+     * animated encoder, and animated WebP/APNG both carry EXIF — a
+     * privacy-sensitive host needs to see that the strip did not happen so it
+     * can branch server-side. Absent means nothing was skipped.
+     */
+    metadataStripSkipped?: boolean
+    /** Why `metadataStripSkipped` was set. */
+    metadataStripSkippedReason?: 'animated-image'
     heicConverted?: boolean
 }
 

--- a/packages/core/tests/steps/image-processing.test.ts
+++ b/packages/core/tests/steps/image-processing.test.ts
@@ -250,7 +250,43 @@ describe('animated images skip the canvas re-encode steps', () => {
             expect(result.type).toBe(type)
             expect(result.metadata.exifStripped).toBeUndefined()
         })
+
+        // #367 item 4: the skip is privacy-relevant (animated WebP and APNG both
+        // carry EXIF), so it leaves a marker the host can read off the file.
+        it(`flags the skipped EXIF strip on ${label}`, async () => {
+            installImageRuntime('reencoded')
+            const original = makeUploadFile(name, type, bytes)
+
+            const result = await exifStep().process(original, ctx)
+
+            expect(result.metadata.metadataStripSkipped).toBe(true)
+            expect(result.metadata.metadataStripSkippedReason).toBe(
+                'animated-image',
+            )
+        })
+
+        // The compress skip is not a metadata-retention event: nothing was asked
+        // to be removed, so it must NOT claim the strip was skipped.
+        it(`does not flag a skipped EXIF strip from the compress step on ${label}`, async () => {
+            installImageRuntime('compressed')
+            const original = makeUploadFile(name, type, bytes)
+
+            const result = await compressStep().process(original, ctx)
+
+            expect(result.metadata.metadataStripSkipped).toBeUndefined()
+        })
     }
+
+    it('does not flag a skipped EXIF strip for a still image the exif step really stripped', async () => {
+        installImageRuntime('reencoded')
+        const original = makeUploadFile()
+
+        const result = await exifStep().process(original, ctx)
+
+        expect(result.metadata.exifStripped).toBe(true)
+        expect(result.metadata.metadataStripSkipped).toBeUndefined()
+        expect(result.metadata.metadataStripSkippedReason).toBeUndefined()
+    })
 
     it('leaves an animated GIF untouched on the web-worker path too', async () => {
         installImageRuntime('compressed')

--- a/packages/react/src/components/FileList.tsx
+++ b/packages/react/src/components/FileList.tsx
@@ -375,6 +375,7 @@ export default memo(function FileList() {
                         {uploadErrorCode
                             ? t(tr.uploadFailedWithCode, {
                                   code: uploadErrorCode,
+                                  message: uploadError,
                               })
                             : t(tr.uploadFailed, { message: uploadError })}
                     </p>

--- a/packages/react/tests/upload-error-slot.test.tsx
+++ b/packages/react/tests/upload-error-slot.test.tsx
@@ -54,7 +54,8 @@ vi.mock('../src/context/UploaderContext', () => ({
             pauseUpload: 'Pause',
             cancel: 'Cancel',
             uploadFailed: 'Upload failed: {{message}}',
-            uploadFailedWithCode: 'Upload failed with error code: {{code}}',
+            uploadFailedWithCode:
+                'Upload failed with error code {{code}}: {{message}}',
         },
     }),
     useUploaderUploadControls: () => ({
@@ -157,5 +158,28 @@ describe('FileList — default upload-error slot (P4/C10)', () => {
         expect(el).not.toBeNull()
         expect(el?.getAttribute('title')).toBe('SignatureDoesNotMatch')
         expect(el?.textContent).toContain('SignatureDoesNotMatch')
+    })
+
+    // #367 item 2: the code used to be the ONLY thing the panel showed, so a
+    // host that returned a useful sentence saw it vanish from the UI.
+    it('renders the host-supplied sentence alongside the code', () => {
+        _uploadStatus = 'FAILED'
+        _uploadError = 'Your plan allows 2 GB; this upload needs 3 GB.'
+        _uploadErrorCode = 'QUOTA_EXCEEDED_CUSTOM'
+        const { container } = render(<FileList />)
+        const el = container.querySelector('[data-testid="upup-upload-error"]')
+        expect(el?.textContent).toBe(
+            'Upload failed with error code QUOTA_EXCEEDED_CUSTOM: Your plan allows 2 GB; this upload needs 3 GB.',
+        )
+    })
+
+    it('renders a markup-looking host message as text, never as HTML', () => {
+        _uploadStatus = 'FAILED'
+        _uploadError = '<img src=x onerror="alert(1)">denied'
+        _uploadErrorCode = 'BAD_REQUEST_CUSTOM'
+        const { container } = render(<FileList />)
+        const el = container.querySelector('[data-testid="upup-upload-error"]')
+        expect(el?.querySelector('img')).toBeNull()
+        expect(el?.textContent).toContain('<img src=x onerror="alert(1)">')
     })
 })

--- a/packages/svelte/src/components/FileList.svelte
+++ b/packages/svelte/src/components/FileList.svelte
@@ -342,7 +342,7 @@ import { isUploadActive, cn } from '@useupup/core/internal'
         title={$uploadErrorCode}
         class="upup-mr-auto upup-text-sm upup-text-red-600 dark:upup-text-red-400"
       >
-        {$uploadErrorCode ? t(tr.uploadFailedWithCode, { code: $uploadErrorCode }) : t(tr.uploadFailed, { message: $uploadError })}
+        {$uploadErrorCode ? t(tr.uploadFailedWithCode, { code: $uploadErrorCode, message: $uploadError }) : t(tr.uploadFailed, { message: $uploadError })}
       </p>
     {/if}
 

--- a/packages/vanilla/src/templates/file-list.ts
+++ b/packages/vanilla/src/templates/file-list.ts
@@ -398,6 +398,7 @@ export function fileList(ctx: UploaderContext): TemplateResult {
                               uploadErrorCode
                                   ? t(tr.uploadFailedWithCode, {
                                         code: uploadErrorCode,
+                                        message: uploadError,
                                     })
                                   : t(tr.uploadFailed, { message: uploadError })
                           }

--- a/packages/vue/src/components/FileList.vue
+++ b/packages/vue/src/components/FileList.vue
@@ -384,7 +384,10 @@ function onRetryClick() {
             >
                 {{
                     uploadErrorCode
-                        ? t(tr.uploadFailedWithCode, { code: uploadErrorCode })
+                        ? t(tr.uploadFailedWithCode, {
+                              code: uploadErrorCode,
+                              message: uploadError,
+                          })
                         : t(tr.uploadFailed, { message: uploadError })
                 }}
             </p>


### PR DESCRIPTION
## Summary

Items 2 and 4 from #367. Two unrelated follow-ups, one commit each.

## Item 2 — the panel shows the host's sentence, not just the code

A failure carrying a machine code rendered through the `uploadFailedWithCode` i18n key, which interpolated `{code}` and nothing else. So an endpoint that returned a useful message saw it reach `onError` and then vanish from the UI. #364 surfaced the message; this is the missing half.

Decision (b): keep the one generic key and give it a second `{message}` slot, rather than branching on the message in component code. Translators therefore control placement.

- `packages/core/src/i18n/ui-translations.ts` bakes `message: '{{message}}'` alongside the existing `code` slot.
- All nine locale bundles carry both slots. English is now `Upload failed with error code {code}: {message}`; each other locale keeps its own phrasing and punctuation (French keeps the spaced colon, Japanese/Chinese keep the fullwidth colon, Arabic keeps its word order).
- `packages/core/src/i18n/types.ts` doc comment updated to the new ICU shape.
- All six framework panels pass both values, identically: `packages/react/src/components/FileList.tsx` (canon), `packages/vue/src/components/FileList.vue`, `packages/svelte/src/components/FileList.svelte`, `packages/angular/src/components/file-list.component.ts`, `packages/vanilla/src/templates/file-list.ts`. Preact re-exports React.

No plumbing was needed: the orchestrator's `upload-error` handler already stores `payload.error.message` as `uploadError` and the code as `uploadErrorCode`, and every panel already reads both. Only the code path ignored the message.

**Rendering is text, never HTML.** React/Vue/Svelte/Angular interpolate into a text node and vanilla's lit `html` template escapes `${}`. A test pins it with an `<img src=x onerror=...>` message.

**On the empty-message case.** The brief allowed a second key variant or trimming. Neither is needed, and that is a deliberate call rather than an omission: all six panels already gate the `upload-error` slot on a truthy `uploadError` (`uploadStatus === FAILED && uploadError`), so the slot cannot render with an empty message and no locale can produce a dangling colon. The existing React test "renders no error slot when FAILED but uploadError is empty" is that gate's pin, and it still passes. Adding a ninth-locale second key would have been nine strings of unreachable code.

### Item 2 tests

- `packages/core/src/__tests__/i18n/ui-translations.test.ts` — a new block: every one of the nine bundles bakes both `{{code}}` and `{{message}}`; every one interpolates both with nothing left unsubstituted; en-US renders the exact expected sentence; a host `overrides.errors.uploadFailedWithCode` of `'{message} [{code}]'` reorders the slots.
- `packages/react/tests/upload-error-slot.test.tsx` — the fixture template gained the slot, the existing code-aware test still passes, plus a test asserting the full rendered sentence contains the host message and one asserting a markup-looking message renders as text with no element created.
- `packages/angular/src/components/file-list.spec.ts` — fixture template updated to the two-slot shape.

### Parity fixtures

`apps/e2e-test/cross-framework/parity-fixtures.json` does not contain the string at all (zero matches for "Upload failed"), and its three stories are mount/selector states that never drive a failure. No regen needed, no six-framework run required.

## Item 4 — a runtime signal when the EXIF strip is skipped

`stripExifData` skips animated GIF/WebP/APNG because canvas has no animated encoder, so re-encoding would keep frame one. Animated WebP and APNG both carry EXIF, which means those files reach storage with exactly the metadata the host asked to remove, silently.

Decision (a): a metadata flag on the file, no new event. The `exif` step (`packages/core/src/steps/exif.ts`) now sets, on its skip path:

```ts
file.metadata = {
    ...file.metadata,
    metadataStripSkipped: true,
    metadataStripSkippedReason: 'animated-image',
}
```

Both fields are new optional members of the existing `UploadFileMetadata` bag in `packages/core/src/types/upload-file.ts` — no top-level `UploadFile` field, so the runtime export pins are untouched. The assign-a-new-metadata-object-onto-the-file shape is the one `thumbnailStep` already uses for annotate-only steps, which is why the existing `expect(result).toBe(original)` assertions still hold.

**The compress step deliberately does not set it.** `imageCompression` skipping an animated image is not a metadata-retention event — nothing was asked to be removed — so the marker there would be a false privacy signal. When both steps are enabled the `exif` step sets it anyway, since it runs first and skips the same files.

### Item 4 tests

`packages/core/tests/steps/image-processing.test.ts`, using the existing `animated-image-fixtures.ts` corpus, across all three animated containers (animated GIF, animated WebP, APNG):

- the flag and the reason are both set by the `exif` step
- the `compress` step does not set the flag
- a still image the `exif` step really stripped carries `exifStripped: true` and neither marker

### Item 4 docs

`apps/landing/content/docs/guides/file-processing.mdx` gains a "Detecting a skipped strip" subsection under EXIF stripping, with an `onFileUploadComplete` example that queues a server-side strip.

## Gates

Run locally, verdicts from raw exit codes:

| gate | result |
| --- | --- |
| `pnpm run test` (turbo, all 28 tasks) | pass |
| `pnpm run typecheck` (31 tasks, test trees included) | pass |
| `pnpm run lint` (20 tasks) | pass |
| `pnpm run vocab:check` | pass, 1400 files clean |
| `prettier --check` on every touched path | pass |

The first `pnpm run test` invocation showed `@useupup/next#build` and `@useupup/mastra#test` red; both are parallel-run artifacts (next's `copy-styles` read react's `tailwind-prefixed.css` mid-write). Each passes alone and the re-run was 28/28.

Refs #367 (items 2 and 4); items 1/3/5 landed in #381; item 6 accepted
