### PR TITLE
chore: correct action pin comments and stale doc statements

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -189,7 +189,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -245,7 +245,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -276,7 +276,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -337,7 +337,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -47,7 +47,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -92,7 +92,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -122,7 +122,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -145,7 +145,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -178,7 +178,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -201,7 +201,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -223,7 +223,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -246,7 +246,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -269,7 +269,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -135,7 +135,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -157,7 +157,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -193,7 +193,7 @@ jobs:
 
             - name: Setup pnpm
               if: steps.creds.outputs.present == 'true'
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               if: steps.creds.outputs.present == 'true'
@@ -254,7 +254,7 @@ jobs:
 
             - name: Setup pnpm
               if: steps.creds.outputs.present == 'true'
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               if: steps.creds.outputs.present == 'true'
@@ -367,7 +367,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -424,7 +424,7 @@ jobs:
 
             - name: Setup pnpm
               if: steps.creds.outputs.present == 'true'
-              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - name: Setup Node.js
               if: steps.creds.outputs.present == 'true'

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,8 +1,10 @@
 name: Publish npm placeholder
 
-# Manual only, by design. This repo's own release flow publishes the root `upup` package, so
-# this workflow deliberately does NOT trigger on `release` — it must never
-# fire as a side effect of that flow.
+# Manual only, by design. This repo's own release flow is changesets, and it
+# publishes the nine `@useupup/*` workspace packages — never `sdk/`. (The root
+# `upup` package is `private: true` and is never published at all.) So this
+# workflow deliberately does NOT trigger on `release` — it must never fire as a
+# side effect of that flow.
 on:
     workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
                   # (git shortlog over the range) and the previous v-tag from them.
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.4.0
+            - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ fumadocs-core headless; there is no longer a standalone docs app), `e2e-test`
 svelte/vanilla/angular/preact` (per-framework style-parity references),
 `next-example`, `mastra` (agents/tools for the interactive playground).
 
+Name reservation (`sdk/`): `@useupup/sdk@0.0.1`, a parked placeholder whose only
+job is to hold the name on npm. It is NOT a workspace package and NOT part of
+the changesets release — it publishes by hand through `publish-sdk.yml`
+(`workflow_dispatch` only, so the release flow can never fire it as a side
+effect). Touching it, or giving it real contents, needs a maintainer decision.
+
 ## Non-negotiable principles
 
 1. **React is the visual canon.** UI changes land in `@useupup/react` first; the
@@ -146,7 +152,7 @@ pnpm run e2e            # the REAL gate — see next section
 pnpm run prettier-check # CI blocks on this (all 9 publishable packages' src, .ts/.tsx ONLY — .vue/.svelte SFC + .css are NOT covered; one root config)
 pnpm run size           # size-limit bundle budgets
 pnpm run audit:prod     # high+ advisories in the publishable prod trees
-pnpm run lint           # eslint flat-config: 9 @useupup/* packages + 3 apps (playground, landing, docs); each leaf is `eslint . --max-warnings 0` so warnings gate (F-784)
+pnpm run lint           # eslint flat-config: 9 @useupup/* packages + 2 apps (playground, landing); each leaf is `eslint . --max-warnings 0` so warnings gate (F-784)
 pnpm run lint:ox        # oxlint fast first-line (built-ins only, seconds)
 pnpm run knip           # dead-code / unused-dep detection (workspace-aware)
 pnpm run env:check      # .env.minio.example ↔ validate-env schema drift guard


### PR DESCRIPTION
Four comment-only corrections found while reading around the release and lint tooling. No SHA changes, no workflow logic changes, no code changes.

## 1. `pnpm/action-setup` pin comments said v4.4.0; the SHA is v6.0.10

All 23 occurrences across four workflows carried `# v4.4.0`:

| Workflow | Occurrences |
|---|---|
| `main.yml` | 10 |
| `nightly.yml` | 7 |
| `e2e.yml` | 5 |
| `publish.yml` | 1 |

Verified rather than assumed. `repos/pnpm/action-setup/git/ref/tags/v6.0.10` returns an **annotated** tag object at `ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3`; dereferencing it via `git/tags/ff378ebe…` gives `"object": {"sha": "0977fd99725f1db4007ccb2928dbb4e90d06cc86", "type": "commit"}`, tagged by Zoltan Kochan on 2026-08-03 with a verified PGP signature. That is exactly the pinned SHA.

**The pin is untouched** — the SHA is what actually runs, and it is correct. Only the trailing comment moved to `# v6.0.10`. This matters for review and for dependabot triage: a comment two majors behind makes the pin look far more stale than it is, and is the kind of thing a reviewer trusts at a glance instead of resolving.

## 2. `CLAUDE.md` lint gate overcounted the apps

The gate line claimed `9 @useupup/* packages + 3 apps (playground, landing, docs)`. There is no `apps/docs` — the docs live in `apps/landing/content/docs/`, which the same file says three paragraphs earlier — and only two apps define a `lint` script:

```
apps/landing/package.json:9:        "lint": "eslint . --max-warnings 0",
apps/playground/package.json:9:        "lint": "eslint . --max-warnings 0",
```

Corrected to `2 apps (playground, landing)`. The `9 @useupup/*` half is right and was left alone: all nine publishable packages define a `lint` script, so `turbo run lint` has 11 leaves.

## 3. `publish-sdk.yml` header rested on a false premise

The header read "This repo's own release flow publishes the root `upup` package". It does not: root `package.json` is `name: upup`, `private: true`, and is never published anywhere. The changesets flow publishes the nine `@useupup/*` workspace packages.

The sentence's actual point — that this workflow must never fire as a side effect of the release flow, hence `workflow_dispatch` only and no `release` trigger — is preserved verbatim and now follows from something true. The rest of the file is unchanged.

## 4. `CLAUDE.md` package map had no `sdk/` entry

`sdk/` holds `@useupup/sdk@0.0.1` and has its own publish workflow, but appeared nowhere in the package map, so nothing in the committed process docs explained what it is or warned against touching it. Added a short entry recording the four things that are not visible from the directory itself: it is a parked name reservation, it is outside the `pnpm-workspace.yaml` globs (verified — the globs are `apps/*` plus explicit `packages/*` entries, no `sdk`), it is outside the changesets release, and it publishes only by manual dispatch.

## Verification

Via `rtk proxy` with the raw exit code.

- `pnpm exec prettier --check CLAUDE.md .github/workflows/*.yml` — exit 0
- `pnpm run vocab:check` — exit 0, 1402 files clean
- Line endings checked byte-wise before and after each workflow edit; unchanged (`e2e`/`main`/`nightly`/`publish-sdk` are LF, `publish` is CRLF, all pre-existing)
- pre-commit (lint-staged + core/react/server suites) and pre-push (typecheck, lint, knip) both ran clean; no `--no-verify`

Stacked behind #398 only in authoring order; the two PRs touch disjoint files and can merge in either order.