### PR TITLE
chore(size): raise the @useupup/core budget to 420 KB, measured

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -4,7 +4,7 @@
         "path": "packages/core/dist/**/*.js",
         "gzip": false,
         "brotli": false,
-        "limit": "410 KB"
+        "limit": "420 KB"
     },
     {
         "name": "@useupup/react",


### PR DESCRIPTION
`@useupup/core`'s budget was 0.89 kB from its ceiling before #393 landed, so the next core change of any size was going to be the one that hit it. #393 is that change.

**Measured, not estimated**

| Commit | `@useupup/core` | Budget |
|---|---|---|
| master `2464bb8` (post-#400 promotion) — [job 103160259345](https://github.com/DevinoSolutions/upup/actions/runs/34566155322/job/103160259345) | 409.11 kB | 410 kB |
| dev `8702e77` (master + #393) — [job 103212277087](https://github.com/DevinoSolutions/upup/actions/runs/34582844149/job/103212277087) | 412.46 kB | 410 kB ❌ |

#393 costs **+3.35 kB** of core: the three Drive listing params, a paginated `drives.list` walk, and the synthetic "Shared with me" folder id both list paths branch on. No dependency was added and nothing moved onto core's mandatory path — principle 6 is intact, this is plain code for a default-off option.

**420 KB, and why that number.** It clears the measured 412.46 kB by 7.5 kB — about 1.8%. Deliberately small: enough that a routine fix does not re-block a promotion, little enough that the next raise is a decision somebody makes on purpose rather than a ceiling nobody is near. A larger jump would buy quiet at the price of the gate meaning anything.

This unblocks the dev→master promotion in #404, which is otherwise green (including `Cross-framework E2E`).
