### PR TITLE
test(scripts): hold the drive-sandbox escaper copy to the core implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test": "turbo run test --continue",
         "test:coverage": "turbo run test:coverage --continue",
         "test:quality": "node scripts/ci/test-quality-guard.mjs",
-        "test:scripts": "node --test scripts/ci/test-quality-guard.test.mjs scripts/ci/resolve-affected-tests.test.mjs scripts/lib/tarball.test.mjs scripts/lib/styles-subpath.test.mjs scripts/lib/release-notes.test.mjs scripts/docs/check-api-sync.test.mjs scripts/docs/check-links.test.mjs scripts/docs/check-coverage.test.mjs scripts/docs/check-snippets.test.mjs",
+        "test:scripts": "node --test scripts/ci/test-quality-guard.test.mjs scripts/ci/resolve-affected-tests.test.mjs scripts/lib/tarball.test.mjs scripts/lib/styles-subpath.test.mjs scripts/lib/release-notes.test.mjs scripts/docs/check-api-sync.test.mjs scripts/docs/check-links.test.mjs scripts/docs/check-coverage.test.mjs scripts/docs/check-snippets.test.mjs scripts/drive-sandbox/seed-escape-twin.test.mjs",
         "docs:api-sync:check": "node scripts/docs/check-api-sync.mjs",
         "docs:links:check": "node scripts/docs/check-links.mjs",
         "docs:snippets:coverage": "node scripts/docs/check-coverage.mjs",

--- a/scripts/drive-sandbox/seed-escape-twin.test.mjs
+++ b/scripts/drive-sandbox/seed-escape-twin.test.mjs
@@ -1,0 +1,108 @@
+// scripts/drive-sandbox/seed-escape-twin.test.mjs
+//
+// Holds `escapeGDriveQueryValue` in seed.mjs to `escapeDriveQueryValue` in
+// packages/core/src/drives/query-escape.ts.
+//
+// The seed script keeps its own copy on purpose. It is a standalone ops script
+// run as `node scripts/drive-sandbox/seed.mjs`, and importing the core function
+// would mean adding `@useupup/core` as a root dependency and refusing to run
+// until the package had been built — a build step to seed a sandbox account.
+// The copy is one expression and the trade is worth it.
+//
+// What is not acceptable is the copy drifting silently. A Drive query literal
+// is single-quoted, so an id carrying a quote closes it early; getting the
+// BACKSLASH-BEFORE-QUOTE order wrong is the classic way to write an escaper
+// that looks correct and escapes nothing.
+//
+// The guarantee is split in two, and neither half is enough alone:
+//
+//   1. `packages/core/tests/drive-query-escape.test.ts` pins what the core
+//      function DOES, over seven cases including the ordering one.
+//   2. This file pins that the seed copy is the SAME EXPRESSION as the one
+//      those cases cover, so the behaviour carries across without this test
+//      having to re-derive it.
+//
+// Comparing source rather than running it is deliberate: seed.mjs calls main()
+// at module scope so it cannot be imported, the core file is TypeScript so it
+// cannot be required from a plain node test, and evaluating extracted source
+// would mean compiling a string — a bad habit to model in a repo's own tests
+// even when the string comes from a tracked file.
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(HERE, '..', '..')
+
+const SEED = resolve(REPO, 'scripts/drive-sandbox/seed.mjs')
+const CORE = resolve(REPO, 'packages/core/src/drives/query-escape.ts')
+
+/**
+ * The body of a one-expression `return`, with the parameter renamed to a fixed
+ * token and runs of whitespace collapsed — so the two copies compare equal
+ * despite different parameter names, indentation or line breaks.
+ *
+ * Deliberately narrow. It matches a single-expression body and nothing else, so
+ * a rewrite into a shape this cannot read fails loudly here rather than being
+ * quietly skipped.
+ */
+function normalisedBody(file, name) {
+    const src = readFileSync(file, 'utf8')
+    const pattern = new RegExp(
+        `function ${name}\\s*\\(\\s*(\\w+)[^)]*\\)[^{]*\\{\\s*return ([\\s\\S]*?)\\n\\}`,
+        'm',
+    )
+    const match = pattern.exec(src)
+    assert.ok(
+        match,
+        `${name} not found in ${file} in the single-return shape this test reads. ` +
+            'If it was rewritten, update this test rather than deleting it — the ' +
+            'two implementations must stay identical.',
+    )
+    const [, param, body] = match
+    return body
+        .trim()
+        .replace(new RegExp(`\\b${param}\\b`, 'g'), 'VALUE')
+        .replace(/\s+/g, ' ')
+}
+
+test('the seed copy is the same expression as the core escaper', () => {
+    assert.equal(
+        normalisedBody(SEED, 'escapeGDriveQueryValue'),
+        normalisedBody(CORE, 'escapeDriveQueryValue'),
+        'the seed copy has drifted from packages/core/src/drives/query-escape.ts — ' +
+            'change both, or make the script import the core one',
+    )
+})
+
+test('that shared expression escapes the backslash before the quote', () => {
+    // The ordering is the whole correctness argument, so it is asserted on the
+    // source directly and not left implied by the equality above: escaping the
+    // quote first leaves the backslash it introduces to be doubled by the
+    // second pass, which turns the escape back into a literal backslash
+    // followed by an unescaped quote — closing the literal it was meant to
+    // protect. `packages/core/tests/drive-query-escape.test.ts` covers what
+    // that means for real values.
+    const body = normalisedBody(CORE, 'escapeDriveQueryValue')
+    const backslashPass = body.indexOf('replace(/\\\\/g')
+    const quotePass = body.indexOf("replace(/'/g")
+    assert.notEqual(backslashPass, -1, 'no backslash-escaping pass found')
+    assert.notEqual(quotePass, -1, 'no quote-escaping pass found')
+    assert.ok(
+        backslashPass < quotePass,
+        'backslashes must be escaped BEFORE quotes',
+    )
+})
+
+test('the seed script still points a reader at the core implementation', () => {
+    assert.match(
+        readFileSync(SEED, 'utf8'),
+        /packages\/core\/src\/drives\/query-escape\.ts/,
+        'the comment above the seed copy must name the file it mirrors',
+    )
+    // And that file must exist, so the pointer cannot rot into a dead path.
+    readFileSync(CORE, 'utf8')
+})


### PR DESCRIPTION
Follow-up to the review nit on #407: `scripts/drive-sandbox/seed.mjs` carries a hand-maintained twin of the core Drive-query escaper, and nothing held the two together.

## Why a test and not an import

The nit offered either. The import is not available here:

- The root `package.json` declares no dependency on `@useupup/core`, so `seed.mjs` cannot resolve it. Adding one would make an ops script that seeds a sandbox Google account refuse to run until the workspace had been built.
- `seed.mjs` calls `main()` at module scope, so it cannot be imported by a test either — importing it would start seeding.

So the guarantee is a test that holds the two implementations identical.

## What the test does

`scripts/drive-sandbox/seed-escape-twin.test.mjs` (three `node:test` cases):

1. **Same expression.** Extracts the single-`return` body of `escapeGDriveQueryValue` from `seed.mjs` and of `escapeDriveQueryValue` from `packages/core/src/drives/query-escape.ts`, renames the parameter to a fixed token, collapses whitespace, and asserts the two are equal. The failure message names the core file and both remedies.
2. **Backslash before quote.** Asserts the ordering on the source directly rather than leaving it implied by the equality — escaping the quote first lets the second pass double the backslash it just introduced, which turns the escape back into a literal backslash followed by an unescaped quote and closes the literal it was meant to protect.
3. **The pointer still points.** The comment above the seed copy must still name `packages/core/src/drives/query-escape.ts`, and that file must exist, so the pointer cannot rot into a dead path.

The seven escape cases themselves stay where they already are, in `packages/core/tests/drive-query-escape.test.ts`. This file's job is to carry that coverage across to the copy, not to re-derive it.

Source comparison rather than execution is deliberate and is explained in the file header: the core file is TypeScript and cannot be required from a plain node test, and evaluating extracted source would mean compiling a string — a bad habit to model in a repo's own tests even when the string comes from a tracked file.

## Proven red, then green

Drifting the seed copy to escape the quote first:

```
✖ the seed copy is the same expression as the core escaper
  AssertionError [ERR_ASSERTION]: the seed copy has drifted from
  packages/core/src/drives/query-escape.ts — change both, or make the
  script import the core one
```

`seed.mjs` was then restored with `git checkout --` and the three cases pass.

## Wiring

Added to the `test:scripts` script in the root `package.json`, so it runs with the other script tests rather than sitting unreferenced.

## Gates

| Gate | Exit |
| --- | --- |
| `test:scripts` | 0 |
| `prettier --check` | 0 |
| `turbo run typecheck` | 0 |
| `turbo run lint` | 0 |
| `knip` | 0 |
| `turbo run test` (28/28) | 0 |
| `test:quality` | 0 |
| docs gates (4) | 0 |

No changeset: this adds a test and changes no published package.
