### PR TITLE
seo(landing): Organization/WebSite entity JSON-LD, AI-crawler robots allow-list, md-twin alternates, HSTS + cf-visitor https redirect

### DIFF
--- a/apps/e2e-test/landing/docs.spec.ts
+++ b/apps/e2e-test/landing/docs.spec.ts
@@ -319,4 +319,99 @@ test.describe('docs', () => {
             await expect(vueTabAgain).toHaveAttribute('aria-selected', 'true')
         }).toPass({ timeout: 15_000 })
     })
+
+    // ── SEO surfaces ──────────────────────────────────────────────────────
+    // The dev server this project boots leaves NEXT_PUBLIC_BASE_URL unset, so
+    // next.config.mjs computes SITE_BASE = https://useupup.com and takes the
+    // PRODUCTION branch of headers()/redirects(). That is what lets these
+    // assertions exercise the real prod rules without a second webServer.
+    const PRODUCTION_ORIGIN = 'https://useupup.com'
+
+    test('docs page declares its canonical URL and its markdown twin as an alternate', async ({
+        page,
+        request,
+    }) => {
+        await page.goto('/docs/getting-started/')
+        await expect(page.locator('link[rel=canonical]')).toHaveAttribute(
+            'href',
+            `${PRODUCTION_ORIGIN}/docs/getting-started/`,
+        )
+        const alternate = page.locator(
+            'link[rel=alternate][type="text/markdown"]',
+        )
+        await expect(alternate).toHaveAttribute(
+            'href',
+            `${PRODUCTION_ORIGIN}/docs-md/getting-started/`,
+        )
+        // Fetch the PATH against this server — following the absolute href
+        // would test production, not the build under test.
+        const href = await alternate.getAttribute('href')
+        const twin = await request.get(new URL(href ?? '').pathname)
+        expect(twin.status()).toBe(200)
+        expect(twin.headers()['content-type']).toContain('text/markdown')
+        // The twin must declare the HTML page as its original, or it is a
+        // duplicate of every docs page under a second URL.
+        expect(twin.headers()['link']).toContain('rel="canonical"')
+        expect(twin.headers()['link']).toContain(
+            `${PRODUCTION_ORIGIN}/docs/getting-started/`,
+        )
+    })
+
+    test('plaintext request identified by the Cloudflare visitor header is redirected to https', async ({
+        request,
+    }) => {
+        const redirected = await request.get('/react/', {
+            headers: { 'cf-visitor': '{"scheme":"http"}' },
+            maxRedirects: 0,
+        })
+        expect(redirected.status()).toBe(308)
+        expect(redirected.headers()['location']).toBe(
+            `${PRODUCTION_ORIGIN}/react/`,
+        )
+        // The header is the ONLY trigger: an ordinary request must still be
+        // served, or the rule would loop every visitor behind the proxy.
+        const plain = await request.get('/react/')
+        expect(plain.status()).toBe(200)
+    })
+
+    test('stale search-console sitemap URL permanently redirects to the live sitemap', async ({
+        request,
+    }) => {
+        // /sitemap-landing.xml is a Docusaurus-era submission that nothing has
+        // ever served; it 404'd until this rule landed.
+        const res = await request.get('/sitemap-landing.xml', {
+            maxRedirects: 0,
+        })
+        expect(res.status()).toBe(308)
+        expect(res.headers()['location']).toContain('/sitemap.xml')
+    })
+
+    test('production responses carry a preload-eligible HSTS header', async ({
+        request,
+    }) => {
+        const res = await request.get('/')
+        expect(res.headers()['strict-transport-security']).toBe(
+            'max-age=63072000; includeSubDomains; preload',
+        )
+    })
+
+    test('robots.txt names the AI crawler allow-list explicitly', async ({
+        request,
+    }) => {
+        const res = await request.get('/robots.txt')
+        expect(res.status()).toBe(200)
+        const body = await res.text()
+        expect(body).toContain('User-Agent: GPTBot')
+        expect(body).toContain('User-Agent: ClaudeBot')
+        expect(body).toContain('User-Agent: PerplexityBot')
+    })
+
+    test('footer links the llms.txt corpus from every page', async ({
+        page,
+    }) => {
+        await page.goto('/docs/getting-started/')
+        await expect(
+            page.locator('footer a[href="/llms.txt"]'),
+        ).toHaveAttribute('href', '/llms.txt')
+    })
 })

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -72,6 +72,46 @@ const nextConfig = {
     // then one trailingSlash hop appends the slash).
     async redirects() {
         return [
+            // http -> https, FIRST so no other rule can answer a plaintext
+            // request with a 200. Keyed on Cloudflare's `cf-visitor` header
+            // (`{"scheme":"http"}`) and NOTHING else: `x-forwarded-proto` is
+            // rewritten by Traefik on the way to this container, so a rule
+            // reading it sees "http" on every request and redirects forever.
+            // Cloudflare's own "Always Use HTTPS" toggle is the belt (an owner
+            // item); this is the braces that lives in the repo and survives a
+            // zone-settings change.
+            //
+            // TWO rules, because Next strips the trailing slash before matching
+            // a source and does NOT re-append it to an ABSOLUTE destination
+            // (it does for relative ones) — a single `${SITE_BASE}/:path*`
+            // sends /react/ to `…/react`, costing a second 308. The first rule
+            // therefore matches extensionless paths only (`[^/.]+` final
+            // segment) and restores the slash; file paths and the bare root
+            // fall through to the second, which must NOT gain one.
+            {
+                source: '/:path((?:[^/]+/)*[^/.]+)',
+                has: [
+                    {
+                        type: 'header',
+                        key: 'cf-visitor',
+                        value: '.*"scheme":"http".*',
+                    },
+                ],
+                destination: `${SITE_BASE}/:path/`,
+                permanent: true,
+            },
+            {
+                source: '/:path*',
+                has: [
+                    {
+                        type: 'header',
+                        key: 'cf-visitor',
+                        value: '.*"scheme":"http".*',
+                    },
+                ],
+                destination: `${SITE_BASE}/:path*`,
+                permanent: true,
+            },
             // The wildcard `/documentation/:path*` rule below also covers the
             // bare path (`:path*` matches zero segments) — this explicit entry
             // is kept for clarity, not necessity.
@@ -121,11 +161,30 @@ const nextConfig = {
                 destination: '/docs/api-reference/upupuploader/required-props/',
                 permanent: true,
             },
+            // Two sitemap URLs still registered in Search Console from the
+            // Docusaurus era, both currently dead: `/sitemap-landing.xml` is a
+            // bare 404 (nothing ever served it), and `/documentation/sitemap.xml`
+            // fell through to the wildcard below, which appends a slash to a
+            // FILE path and lands on the docs catch-all's 404. GSC has been
+            // reporting "couldn't fetch" for both ever since. Extension paths
+            // get no trailing-slash hop, so each of these is a single 308.
+            // They must precede the wildcard. (Owner follow-up: delete the two
+            // stale submissions in Search Console once these are live.)
+            {
+                source: '/sitemap-landing.xml',
+                destination: '/sitemap.xml',
+                permanent: true,
+            },
+            {
+                source: '/documentation/sitemap.xml',
+                destination: '/sitemap.xml',
+                permanent: true,
+            },
             // Destination carries the trailing slash so trailingSlash:true
             // does not have to spend a SECOND 308 appending it. Safe here only
             // because every extensionless legacy path maps to a real page and
-            // the two file paths under /documentation are handled by the
-            // explicit llms rules above — a slash appended to a file URL would
+            // the file paths under /documentation are handled by the explicit
+            // llms + sitemap rules above — a slash appended to a file URL would
             // break it (Next never slashes paths with an extension).
             {
                 source: '/documentation/:path*',
@@ -137,12 +196,30 @@ const nextConfig = {
             // /documentation/* -> /docs/* hop first (staying on the alias
             // host), then the /docs/* rule below moves it to the main host.
             //
-            // The three explicit rules come before the two catch-alls because
-            // a catch-all destination of `/docs/:path*/` is wrong for exactly
+            // The explicit rules come before the two catch-alls because a
+            // catch-all destination of `/docs/:path*/` is wrong for exactly
             // two shapes: an EMPTY `:path*` (which would render `/docs//`) and
             // a FILE path (which must not gain a trailing slash). Listing them
             // explicitly lets the catch-alls stay slashed for the page shapes
             // that are 99% of alias traffic.
+            //
+            // robots.txt and sitemap.xml are the file paths a crawler probes on
+            // any host it meets. Without these two they took the catch-all to
+            // `${SITE_BASE}/docs/robots.txt/`, then a trailing-slash hop, then
+            // the docs catch-all's 404 — a broken robots on a live alias host.
+            // They belong on the APEX copies, not under /docs.
+            {
+                source: '/robots.txt',
+                has: [{ type: 'host', value: DOCS_ALIAS_HOST }],
+                destination: `${SITE_BASE}/robots.txt`,
+                permanent: true,
+            },
+            {
+                source: '/sitemap.xml',
+                has: [{ type: 'host', value: DOCS_ALIAS_HOST }],
+                destination: `${SITE_BASE}/sitemap.xml`,
+                permanent: true,
+            },
             {
                 source: '/llms.txt',
                 has: [{ type: 'host', value: DOCS_ALIAS_HOST }],
@@ -200,11 +277,35 @@ const nextConfig = {
             },
         ]
     },
-    // Non-production hosts (dev, previews) serve a byte-identical copy of the
-    // whole site. robots.txt disallows crawling there; this header is what
-    // actually keeps a URL discovered some other way out of the index.
+    // Two mutually exclusive header sets.
+    //
+    // PRODUCTION: HSTS. Two years + includeSubDomains + preload is the
+    // preload-list-eligible value; the site is https-only in practice and the
+    // cf-visitor redirect above guarantees a plaintext request never gets a
+    // 200, so there is no http-only subdomain this can strand. (Submitting to
+    // hstspreload.org is an owner step, taken only after the header has been
+    // live for a while — `preload` in the value is a prerequisite, not the
+    // submission itself.)
+    //
+    // NON-PRODUCTION (dev, previews): those hosts serve a byte-identical copy
+    // of the whole site. robots.txt disallows crawling there; this header is
+    // what actually keeps a URL discovered some other way out of the index.
+    // They get no HSTS — a preload directive from a preview host is a
+    // liability, not a protection.
     async headers() {
-        if (IS_PRODUCTION_SITE) return []
+        if (IS_PRODUCTION_SITE) {
+            return [
+                {
+                    source: '/:path*',
+                    headers: [
+                        {
+                            key: 'Strict-Transport-Security',
+                            value: 'max-age=63072000; includeSubDomains; preload',
+                        },
+                    ],
+                },
+            ]
+        }
         return [
             {
                 source: '/:path*',

--- a/apps/landing/src/__tests__/seo-surfaces.test.ts
+++ b/apps/landing/src/__tests__/seo-surfaces.test.ts
@@ -1,0 +1,222 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import robots from '@/app/robots'
+import sitemap from '@/app/sitemap'
+import EntityStructuredData from '@/components/StructuredData/EntityStructuredData'
+import StructuredData from '@/components/StructuredData'
+import { AI_CRAWLER_USER_AGENTS } from '@/lib/seo/ai-crawlers'
+
+// The public site's machine-readable surfaces — sitemap, robots, JSON-LD — are
+// the ones nobody looks at until a search engine has already acted on them.
+// Every assertion here pins a decision that was made deliberately and would be
+// silently reversible otherwise (a fake lastmod, a stray /mobile-demo entry, a
+// Review node nobody can substantiate).
+
+const PRODUCTION_ORIGIN = 'https://useupup.com'
+
+/** Every `application/ld+json` payload in a rendered markup string. */
+function parseJsonLdBlocks(markup: string): unknown[] {
+    const blocks = [
+        ...markup.matchAll(
+            /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g,
+        ),
+    ]
+    return blocks.map(match => JSON.parse(match[1]) as unknown)
+}
+
+/** Flattens `@graph` containers so nodes can be looked up by `@type`. */
+function flattenGraph(documents: unknown[]): Record<string, unknown>[] {
+    const nodes: Record<string, unknown>[] = []
+    for (const doc of documents) {
+        const record = doc as Record<string, unknown>
+        const graph = record['@graph']
+        if (Array.isArray(graph))
+            nodes.push(...(graph as Record<string, unknown>[]))
+        else nodes.push(record)
+    }
+    return nodes
+}
+
+function nodeOfType(
+    nodes: Record<string, unknown>[],
+    type: string,
+): Record<string, unknown> {
+    const found = nodes.find(node => node['@type'] === type)
+    expect(found, `no ${type} node in the rendered JSON-LD`).toBeDefined()
+    return found as Record<string, unknown>
+}
+
+describe('sitemap enumerates only canonical, indexable page URLs', () => {
+    const entries = sitemap()
+
+    it('lists the homepage, six framework pages, support and privacy, and all 64 docs pages', () => {
+        // 1 home + 6 frameworks + support + privacy + 64 fumadocs pages. The
+        // docs count is independently pinned by docs-source.test.ts, so a page
+        // added to content/docs updates both or neither.
+        expect(entries).toHaveLength(1 + 6 + 2 + 64)
+    })
+
+    it('points every entry at the production origin with the trailing slash the site actually serves', () => {
+        for (const entry of entries) {
+            expect(entry.url.startsWith(`${PRODUCTION_ORIGIN}/`)).toBe(true)
+            expect(entry.url.endsWith('/')).toBe(true)
+        }
+    })
+
+    it('omits the demo harness, the API routes, and the agent-only text surfaces', () => {
+        // /mobile-demo and /api are robots-disallowed; /docs-md and /llms*.txt
+        // are alternate representations of pages already listed here, not pages.
+        const excluded = ['/mobile-demo', '/api/', '/docs-md', '/llms']
+        for (const entry of entries) {
+            for (const fragment of excluded) {
+                expect(
+                    entry.url.includes(fragment),
+                    `${entry.url} must not contain ${fragment}`,
+                ).toBe(false)
+            }
+        }
+    })
+
+    it('stamps no lastModified date on any entry', () => {
+        // A build-time `new Date()` on all 73 URLs claimed the whole site
+        // changed on every deploy; Google's response to an uncorroborated
+        // lastmod is to ignore the field site-wide. No real per-page date
+        // exists, so the field stays absent rather than invented.
+        for (const entry of entries) {
+            expect(entry.lastModified, `${entry.url} lastModified`).toBe(
+                undefined,
+            )
+        }
+    })
+})
+
+describe('robots.txt grants crawl access per host and names the AI agents', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+        vi.resetModules()
+    })
+
+    it('allows the whole site to the wildcard agent except the API and demo harness', () => {
+        const rules = [robots().rules].flat()
+        const wildcard = rules.find(rule => rule.userAgent === '*')
+        expect(wildcard?.allow).toBe('/')
+        expect(wildcard?.disallow).toEqual(['/api/', '/mobile-demo/'])
+    })
+
+    it('carries a second rule listing exactly the AI crawler allow-list', () => {
+        const rules = [robots().rules].flat()
+        const agentRule = rules.find(rule => Array.isArray(rule.userAgent))
+        expect(agentRule?.userAgent).toEqual([...AI_CRAWLER_USER_AGENTS])
+        expect(agentRule?.allow).toBe('/')
+        // The named agents must never get a laxer disallow set than `*`.
+        expect(agentRule?.disallow).toEqual(['/api/', '/mobile-demo/'])
+    })
+
+    it('advertises the production sitemap URL', () => {
+        expect(robots().sitemap).toBe(`${PRODUCTION_ORIGIN}/sitemap.xml`)
+    })
+
+    it('blanket-disallows crawling when the deployment is not the production site', async () => {
+        // clientEnv is parsed once at module load, so the stub has to land
+        // before a FRESH import of the robots route and the site-url helper
+        // underneath it.
+        vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://dev.useupup.com')
+        vi.resetModules()
+        const devRobots = (await import('@/app/robots')).default
+        const result = devRobots()
+        expect(result.rules).toEqual([{ userAgent: '*', disallow: '/' }])
+        expect(result.sitemap).toBe('https://dev.useupup.com/sitemap.xml')
+    })
+})
+
+describe('entity JSON-LD ties the brand to one referenced organization', () => {
+    const entityNodes = flattenGraph(
+        parseJsonLdBlocks(
+            renderToStaticMarkup(createElement(EntityStructuredData)),
+        ),
+    )
+
+    it('describes the Organization with a stable id, alternate names, and verified profiles', () => {
+        const org = nodeOfType(entityNodes, 'Organization')
+        expect(org['@id']).toBe(`${PRODUCTION_ORIGIN}/#organization`)
+        expect(org.name).toBe('upup')
+        expect(org.alternateName).toContain('useupup')
+        expect(org.alternateName).toContain('@useupup')
+        const sameAs = org.sameAs as string[]
+        expect(sameAs.length).toBeGreaterThanOrEqual(2)
+        for (const profile of sameAs)
+            expect(profile.startsWith('https://')).toBe(true)
+    })
+
+    it('names Devino as the parent organization', () => {
+        const org = nodeOfType(entityNodes, 'Organization')
+        expect(org.parentOrganization).toEqual({
+            '@type': 'Organization',
+            name: 'Devino',
+            url: 'https://devino.ca/',
+        })
+    })
+
+    it('makes the WebSite publisher reference the organization node by id', () => {
+        const site = nodeOfType(entityNodes, 'WebSite')
+        expect(site['@id']).toBe(`${PRODUCTION_ORIGIN}/#website`)
+        expect(site.publisher).toEqual({
+            '@id': `${PRODUCTION_ORIGIN}/#organization`,
+        })
+    })
+
+    it('makes the page-level SoftwareApplication publisher reference the same organization node', () => {
+        const pageNodes = flattenGraph(
+            parseJsonLdBlocks(
+                renderToStaticMarkup(createElement(StructuredData)),
+            ),
+        )
+        const app = nodeOfType(pageNodes, 'SoftwareApplication')
+        expect(app['@id']).toBe(`${PRODUCTION_ORIGIN}/#software`)
+        expect(app.publisher).toEqual({
+            '@id': `${PRODUCTION_ORIGIN}/#organization`,
+        })
+        expect(app.author).toEqual({
+            '@id': `${PRODUCTION_ORIGIN}/#organization`,
+        })
+    })
+
+    it('emits no AggregateRating or Review anywhere in the rendered markup', () => {
+        // We have no first-party review corpus. Rating markup we cannot
+        // substantiate is a manual-action risk, so its absence is a pin, not
+        // an omission — this fails the moment someone adds one.
+        const markup =
+            renderToStaticMarkup(createElement(EntityStructuredData)) +
+            renderToStaticMarkup(createElement(StructuredData))
+        expect(markup).not.toContain('AggregateRating')
+        expect(markup).not.toContain('"Review"')
+    })
+})
+
+describe('AI crawler allow-list holds the exact agreed agent names', () => {
+    it('pins all eighteen user-agent tokens in their published spelling', () => {
+        // Spelling is load-bearing: robots.txt user-agent matching is on these
+        // literal tokens, so a "tidied" name silently drops that agent's group.
+        expect([...AI_CRAWLER_USER_AGENTS]).toEqual([
+            'GPTBot',
+            'OAI-SearchBot',
+            'ChatGPT-User',
+            'ClaudeBot',
+            'Claude-User',
+            'Claude-SearchBot',
+            'anthropic-ai',
+            'PerplexityBot',
+            'Perplexity-User',
+            'Google-Extended',
+            'Googlebot',
+            'Bingbot',
+            'Applebot',
+            'Applebot-Extended',
+            'CCBot',
+            'Amazonbot',
+            'Bytespider',
+            'meta-externalagent',
+        ])
+    })
+})

--- a/apps/landing/src/app/docs-md/[[...slug]]/route.ts
+++ b/apps/landing/src/app/docs-md/[[...slug]]/route.ts
@@ -1,4 +1,5 @@
 import { loadPages } from '@/lib/docs/llms'
+import { canonicalUrl } from '@/lib/site-url'
 
 // One raw-markdown endpoint per docs page, consumed by the "Copy page" button.
 // Frozen at build time like the llms.txt routes — a docs edit appears only
@@ -28,7 +29,16 @@ export async function GET(
     // lives in frontmatter and is rendered as the <h1> on the article page), so
     // prepend it — mirrors buildLlmsFull's per-page shape.
     const markdown = `# ${page.title}\n\n${page.body}\n`
+    // RFC 8288 canonical link. This route serves the same content as the HTML
+    // docs page under a second URL, so without it a crawler that discovers the
+    // twin has two competing originals. A header (rather than a noindex) is the
+    // right tool here: agents are welcome to fetch and quote these bytes, they
+    // just must not treat the twin as a page in its own right.
+    const canonical = canonicalUrl(target ? `docs/${target}` : 'docs')
     return new Response(markdown, {
-        headers: { 'content-type': 'text/markdown; charset=utf-8' },
+        headers: {
+            'content-type': 'text/markdown; charset=utf-8',
+            link: `<${canonical}>; rel="canonical"`,
+        },
     })
 }

--- a/apps/landing/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import { DocsToc } from '@/components/docs/DocsToc'
 import { DocsHome } from '@/components/docs/DocsHome'
 import { DocsPageNav } from '@/components/docs/DocsPageNav'
 import { DocsCopyPage } from '@/components/docs/DocsCopyPage'
+import { DocsStructuredData } from '@/components/docs/DocsStructuredData'
 import { canonicalUrl, siteUrl } from '@/lib/site-url'
 
 // content/docs is edited on the canonical master branch on GitHub.
@@ -33,11 +34,22 @@ export async function generateMetadata(props: {
     const description = page.data.description
     const url = canonicalUrl(slug?.length ? `docs/${slug.join('/')}` : 'docs')
     const image = `${siteUrl()}/img/social-card.png`
+    // The raw-markdown twin is an alternate REPRESENTATION of this page, not a
+    // second page. Declaring it renders <link rel="alternate"
+    // type="text/markdown">, which is how an agent finds the token-cheap copy
+    // without us needing it to be indexed in its own right (the route answers
+    // with a `Link: …; rel="canonical"` header pointing back here).
+    const markdownUrl = `${siteUrl()}/docs-md/${
+        slug?.length ? `${slug.join('/')}/` : ''
+    }`
 
     return {
         title,
         description,
-        alternates: { canonical: url },
+        alternates: {
+            canonical: url,
+            types: { 'text/markdown': markdownUrl },
+        },
         openGraph: {
             title,
             description,
@@ -80,8 +92,27 @@ export default async function DocsPage(props: {
                     with the copy button, so no extra bottom margin here. */}
                 <div className="flex items-start justify-between gap-4">
                     <DocsBreadcrumb tree={tree} url={url} />
-                    <DocsCopyPage mdUrl={mdUrl} />
+                    {/* The Copy button fetches the twin from JS; this anchor is
+                        the crawlable path to the same bytes — a link an agent
+                        (or a person who wants the markdown) can actually
+                        follow. Both point at the slashed canonical URL. */}
+                    <div className="flex items-center gap-2">
+                        <DocsCopyPage mdUrl={mdUrl} />
+                        <a
+                            href={mdUrl}
+                            data-testid="docs-view-markdown"
+                            className="inline-flex items-center rounded-md border border-black/5 px-2.5 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:border-black/10 hover:text-gray-900 dark:border-white/10 dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-white"
+                        >
+                            View as Markdown
+                        </a>
+                    </div>
                 </div>
+                <DocsStructuredData
+                    tree={tree}
+                    url={url}
+                    title={page.data.title}
+                    description={page.data.description}
+                />
                 {/* prose-code:before/after content-none: the typography
                     plugin's default renders literal backtick glyphs around
                     inline code; the chip styling replaces them, scoped via

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Providers } from '@/components/providers'
 import { PostHogProvider } from '@/components/posthog-provider'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
+import EntityStructuredData from '@/components/StructuredData/EntityStructuredData'
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -152,6 +153,11 @@ export default function RootLayout({
             })();
           `}
                 </Script>
+                {/* Organization + WebSite JSON-LD. It lives in the ROOT
+                    layout on purpose: the entity graph has to be on every
+                    page — the 64 docs pages are the bulk of the indexable
+                    surface and they mount no page-level <StructuredData/>. */}
+                <EntityStructuredData />
                 {process.env.NODE_ENV === 'production' && (
                     <>
                         <Script

--- a/apps/landing/src/app/mobile-demo/layout.tsx
+++ b/apps/landing/src/app/mobile-demo/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next'
+
+// This segment exists ONLY to carry metadata. `page.tsx` is `'use client'`
+// (it reads useSearchParams), and a client component cannot export `metadata` —
+// so the route was serving 200 HTML with the ROOT layout's title, description
+// and og:url, no canonical, and no robots directive.
+//
+// robots.txt already has `Disallow: /mobile-demo/`, which is the belt, not the
+// braces: Disallow blocks CRAWLING, not INDEXING — a URL discovered from an
+// external link can still surface as a title-less result under the homepage's
+// title, and because crawling is blocked Google would never read a noindex
+// META tag either. The `X-Robots-Tag`-equivalent directive emitted here is
+// rendered into the HTML at build time, so it applies the moment anything does
+// fetch the page. Keep BOTH.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+}
+
+export default function MobileDemoLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return children
+}

--- a/apps/landing/src/app/robots.ts
+++ b/apps/landing/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next'
+import { AI_CRAWLER_USER_AGENTS } from '@/lib/seo/ai-crawlers'
 import { isProductionSite, siteUrl } from '@/lib/site-url'
 
 // Replaces the former static public/robots.txt, which hardcoded the PRODUCTION
@@ -27,12 +28,27 @@ export default function robots(): MetadataRoute.Robots {
         }
     }
 
+    // ONE disallow set, shared by both groups. A named AI crawler that got a
+    // laxer list than `*` would be a side door into /api/ and the demo harness;
+    // sharing the constant makes divergence impossible rather than unlikely.
+    const disallow = ['/api/', '/mobile-demo/']
+
     return {
         rules: [
             {
                 userAgent: '*',
                 allow: '/',
-                disallow: ['/api/', '/mobile-demo/'],
+                disallow,
+            },
+            // The `*` rule above already permits these agents. Naming them is
+            // an explicit, auditable allow: several are opt-out tokens
+            // (Google-Extended, Applebot-Extended, anthropic-ai) whose absence
+            // reads as "undecided" to a reviewer, and the docs corpus + llms.txt
+            // exist precisely so these crawlers can quote us accurately.
+            {
+                userAgent: [...AI_CRAWLER_USER_AGENTS],
+                allow: '/',
+                disallow,
             },
         ],
         sitemap,

--- a/apps/landing/src/app/sitemap.ts
+++ b/apps/landing/src/app/sitemap.ts
@@ -13,32 +13,33 @@ const HIGH_VALUE_DOCS = new Set([
     '/docs/quickstarts/next',
 ])
 
+// No `lastModified` anywhere below, deliberately. It used to be a single
+// `new Date()` evaluated once per build and stamped on all 73 URLs, which told
+// Google that every page changed on every deploy — Google's documented
+// response to a lastmod it cannot corroborate is to ignore the field for the
+// whole site. There is no real per-page date to use yet (content/docs carries
+// no frontmatter dates and there is no build-time git-mtime map), and an
+// invented one is worse than an absent one. Omitting it is valid sitemap XML.
 export default function sitemap(): MetadataRoute.Sitemap {
-    const lastModified = new Date()
-
     return [
         {
             url: canonicalUrl(),
-            lastModified,
             changeFrequency: 'weekly',
             priority: 1,
         },
         // Per-framework landing pages (/react, /vue, …) — high-value entry points.
         ...FRAMEWORK_IDS.map((id): MetadataRoute.Sitemap[number] => ({
             url: canonicalUrl(id),
-            lastModified,
             changeFrequency: 'weekly',
             priority: 0.9,
         })),
         {
             url: canonicalUrl('support'),
-            lastModified,
             changeFrequency: 'monthly',
             priority: 0.4,
         },
         {
             url: canonicalUrl('privacy'),
-            lastModified,
             changeFrequency: 'yearly',
             priority: 0.3,
         },
@@ -47,7 +48,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
         // to forget. page.url already carries the /docs prefix.
         ...source.getPages().map((page): MetadataRoute.Sitemap[number] => ({
             url: canonicalUrl(page.url),
-            lastModified,
             changeFrequency: 'monthly',
             priority: HIGH_VALUE_DOCS.has(page.url.replace(/\/$/, ''))
                 ? 0.8

--- a/apps/landing/src/components/Footer/index.tsx
+++ b/apps/landing/src/components/Footer/index.tsx
@@ -96,6 +96,18 @@ export default function Footer() {
                                     FAQ
                                 </Link>
                             </li>
+                            <li>
+                                {/* A plain <a>: /llms.txt is a rewrite to a
+                                    text route, not an app page, so next/link's
+                                    client navigation has nothing to render.
+                                    This is also the site's ONLY crawlable link
+                                    to the corpus — the convention is a
+                                    well-known path, but a linked file is the
+                                    one an agent finds by following the site. */}
+                                <a href="/llms.txt" className={FOOTER_LINK}>
+                                    llms.txt
+                                </a>
+                            </li>
                         </ul>
                     </div>
 

--- a/apps/landing/src/components/StructuredData/EntityStructuredData.tsx
+++ b/apps/landing/src/components/StructuredData/EntityStructuredData.tsx
@@ -1,0 +1,76 @@
+// Server component: the SITE-WIDE entity graph — Organization + WebSite.
+//
+// Rendered from the root layout, so it is on every page including all 64 docs
+// pages. That placement is the point: the brand query "upup" returns this site
+// at position ~6 with a 0.3% CTR because nothing on the site ever told a search
+// engine that "upup" the word is an entity with a repo, an npm scope, a chat
+// server, and a parent company. Page-level nodes (SoftwareApplication, FAQPage,
+// the docs TechArticle/BreadcrumbList) live with their pages and point back
+// here by @id, so the whole site describes ONE organization rather than 73
+// unrelated documents.
+//
+// Every `sameAs` URL is verified live before it is added — a dead profile link
+// is a negative entity signal, not a neutral one. Never add AggregateRating or
+// Review here: we have no first-party review corpus, and inventing one is both
+// a policy violation and a manual-action risk.
+
+import { canonicalUrl, siteUrl } from '@/lib/site-url'
+
+/** The one Organization node every other node references. */
+export const ORGANIZATION_ID = `${siteUrl()}/#organization`
+/** The one WebSite node; docs articles declare themselves `isPartOf` it. */
+export const WEBSITE_ID = `${siteUrl()}/#website`
+/** The one SoftwareApplication node (emitted page-level by ./index). */
+export const SOFTWARE_APPLICATION_ID = `${siteUrl()}/#software`
+
+// Verified 2026-09-12: GitHub repo 200; the npm package resolves on the
+// registry (`@useupup/react`, latest 3.3.3); the Discord invite 301s to
+// discord.com/invite/… and the invite API returns a live, non-expiring guild.
+const GITHUB_URL = 'https://github.com/DevinoSolutions/upup'
+const NPM_URL = 'https://www.npmjs.com/package/@useupup/react'
+const DISCORD_URL = 'https://discord.gg/ny5WUE9ayc'
+
+const organization = {
+    '@type': 'Organization',
+    '@id': ORGANIZATION_ID,
+    name: 'upup',
+    // The brand is searched under all of these: the bare word, the npm scope,
+    // the handle, and the descriptive phrase. alternateName is how a knowledge
+    // graph learns they are the same thing.
+    alternateName: ['useupup', '@useupup', 'upup file uploader'],
+    url: canonicalUrl(),
+    logo: {
+        '@type': 'ImageObject',
+        url: `${siteUrl()}/img/logo.png`,
+    },
+    sameAs: [GITHUB_URL, NPM_URL, DISCORD_URL],
+    parentOrganization: {
+        '@type': 'Organization',
+        name: 'Devino',
+        url: 'https://devino.ca/',
+    },
+}
+
+const website = {
+    '@type': 'WebSite',
+    '@id': WEBSITE_ID,
+    name: 'upup',
+    url: canonicalUrl(),
+    publisher: { '@id': ORGANIZATION_ID },
+}
+
+// One @graph rather than two scripts: the nodes reference each other by @id,
+// and a single graph is what makes those references resolvable in one parse.
+const entityGraph = {
+    '@context': 'https://schema.org',
+    '@graph': [organization, website],
+}
+
+export default function EntityStructuredData() {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(entityGraph) }}
+        />
+    )
+}

--- a/apps/landing/src/components/StructuredData/index.tsx
+++ b/apps/landing/src/components/StructuredData/index.tsx
@@ -5,12 +5,21 @@
 
 import { faqs } from '@/lib/faqs'
 import { canonicalUrl } from '@/lib/site-url'
+import {
+    ORGANIZATION_ID,
+    SOFTWARE_APPLICATION_ID,
+} from './EntityStructuredData'
 
 const GITHUB_URL = 'https://github.com/DevinoSolutions/upup'
 
+// The site-wide Organization/WebSite nodes are emitted from the root layout
+// (./EntityStructuredData) so they reach every page including the docs. This
+// application node names its author/publisher by @id instead of repeating the
+// organization inline — one entity, referenced, not seven copies.
 const softwareApplication = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
+    '@id': SOFTWARE_APPLICATION_ID,
     name: 'upup',
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
@@ -24,6 +33,8 @@ const softwareApplication = {
         priceCurrency: 'USD',
     },
     sameAs: [GITHUB_URL],
+    author: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
 }
 
 const faqPage = {

--- a/apps/landing/src/components/docs/DocsHome.tsx
+++ b/apps/landing/src/components/docs/DocsHome.tsx
@@ -225,6 +225,22 @@ export function DocsHome() {
                         </motion.div>
                     ))}
                 </div>
+                {/* The machine-readable entry point, as a real anchor. The
+                    "AI assistants" card above explains llms.txt; this is the
+                    link that actually reaches it — a crawler cannot follow
+                    prose, and the corpus was previously unlinked from every
+                    HTML page on the site. */}
+                <p className="mt-6 text-sm text-gray-600 dark:text-gray-400">
+                    Reading these docs with an agent? Start from{' '}
+                    <a
+                        href="/llms.txt"
+                        data-testid="docs-llms-link"
+                        className="font-medium text-gray-900 underline underline-offset-4 transition-colors hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
+                    >
+                        llms.txt
+                    </a>
+                    .
+                </p>
             </div>
         </div>
     )

--- a/apps/landing/src/components/docs/DocsStructuredData.tsx
+++ b/apps/landing/src/components/docs/DocsStructuredData.tsx
@@ -1,0 +1,72 @@
+// Server component: the per-docs-page JSON-LD — BreadcrumbList + TechArticle.
+//
+// Built from the SAME `tree`/`url` inputs <DocsBreadcrumb> renders visually, so
+// the markup can never describe a different hierarchy than the page shows. The
+// two nodes point at the site-wide entities by @id (emitted once from the root
+// layout) rather than restating publisher details per page.
+//
+// No `datePublished`/`dateModified`: content/docs carries no frontmatter dates
+// and there is no build-time git-mtime map yet. An invented date is worse than
+// no date — Google treats a date it can't corroborate in the page as a quality
+// signal against the markup, so the field stays out until a real source exists.
+
+import {
+    ORGANIZATION_ID,
+    WEBSITE_ID,
+} from '@/components/StructuredData/EntityStructuredData'
+import { findTrail, type SidebarNode } from '@/lib/docs/sidebar-tree'
+import { canonicalUrl } from '@/lib/site-url'
+
+export function DocsStructuredData({
+    tree,
+    url,
+    title,
+    description,
+}: {
+    tree: SidebarNode[]
+    url: string
+    title: string
+    description?: string
+}) {
+    // Same call the visual breadcrumb makes; the "Docs" root crumb is rendered
+    // unconditionally there, so it leads the list here too.
+    const trail = findTrail(tree, url) ?? []
+    const crumbs: { name: string; url?: string }[] = [
+        { name: 'Docs', url: '/docs' },
+        ...trail.map(node => ({ name: node.name, url: node.url })),
+    ]
+
+    const breadcrumbList = {
+        '@type': 'BreadcrumbList',
+        itemListElement: crumbs.map((crumb, i) => ({
+            '@type': 'ListItem',
+            position: i + 1,
+            name: crumb.name,
+            // A folder with no index page has no URL to point at; schema.org
+            // allows a ListItem to carry only a name, so omit `item` instead
+            // of fabricating a target.
+            ...(crumb.url ? { item: canonicalUrl(crumb.url) } : {}),
+        })),
+    }
+
+    const techArticle = {
+        '@type': 'TechArticle',
+        headline: title,
+        ...(description ? { description } : {}),
+        url: canonicalUrl(url),
+        isPartOf: { '@id': WEBSITE_ID },
+        publisher: { '@id': ORGANIZATION_ID },
+    }
+
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@graph': [breadcrumbList, techArticle],
+                }),
+            }}
+        />
+    )
+}

--- a/apps/landing/src/lib/seo/ai-crawlers.ts
+++ b/apps/landing/src/lib/seo/ai-crawlers.ts
@@ -1,0 +1,44 @@
+/**
+ * The AI/answer-engine crawlers robots.txt names explicitly.
+ *
+ * The `*` rule already allows them — this second group exists because an
+ * unnamed crawler is an unproven one. Several of these agents (Google-Extended,
+ * Applebot-Extended, anthropic-ai) are OPT-OUT tokens whose absence is
+ * ambiguous to auditors, and answer engines publish these exact names as the
+ * string they match; spelling them out is how the allow decision becomes
+ * legible in the artifact a reviewer (or an owner) actually reads.
+ *
+ * Order is grouped by operator, not alphabetical, so a name added for a vendor
+ * lands next to its siblings. The list is pinned by
+ * `src/__tests__/seo-surfaces.test.ts` — adding or dropping a name is a
+ * deliberate policy change, so update the pin in the same commit.
+ */
+export const AI_CRAWLER_USER_AGENTS = [
+    // OpenAI: training crawler, search index, and on-demand user fetches.
+    'GPTBot',
+    'OAI-SearchBot',
+    'ChatGPT-User',
+    // Anthropic: index, on-demand user fetch, search, and the legacy token.
+    'ClaudeBot',
+    'Claude-User',
+    'Claude-SearchBot',
+    'anthropic-ai',
+    // Perplexity: index + on-demand user fetch.
+    'PerplexityBot',
+    'Perplexity-User',
+    // Google: Gemini/AI-Overviews opt-out token plus the search crawler that
+    // actually fetches the bytes those surfaces quote.
+    'Google-Extended',
+    'Googlebot',
+    // Microsoft/Copilot.
+    'Bingbot',
+    // Apple: Siri/Spotlight crawler + its AI-training opt-out token.
+    'Applebot',
+    'Applebot-Extended',
+    // Common Crawl — the corpus most open models are trained from.
+    'CCBot',
+    // Amazon (Alexa/Rufus), ByteDance (Doubao/TikTok search), Meta AI.
+    'Amazonbot',
+    'Bytespider',
+    'meta-externalagent',
+] as const

--- a/scripts/docs/check-links.mjs
+++ b/scripts/docs/check-links.mjs
@@ -49,13 +49,16 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const DEFAULT_CONTENT_DIR = resolve(HERE, '../../apps/landing/content/docs')
 const DEFAULT_NEXT_CONFIG = resolve(HERE, '../../apps/landing/next.config.mjs')
 
-// Targets that resolve via next.config.mjs rewrites rather than a content
-// page — valid link/redirect destinations that own no .mdx file.
+// Targets that resolve via next.config.mjs rewrites or Next metadata routes
+// (app/robots.ts, app/sitemap.ts) rather than a content page — valid
+// link/redirect destinations that own no .mdx file.
 const NON_PAGE_TARGETS = new Set([
     '/docs/llms.txt',
     '/docs/llms-full.txt',
     '/llms.txt',
     '/llms-full.txt',
+    '/robots.txt',
+    '/sitemap.xml',
 ])
 
 // ── github-slugger v2 (rehype-slug) — replicated verbatim ──────────────────


### PR DESCRIPTION
## What / why

The 2026-09-11 fleet SEO pull says the site is found but not *understood*:

- The brand query **"upup" drew 663 impressions at average position 6.1 and 2 clicks.** Being on page one for your own name and getting a 0.3% CTR is an entity problem, not a ranking problem: nothing on the site ever told a search engine that "upup" is a thing with a repo, an npm scope, a chat server and a parent company. There was **no `Organization` and no `WebSite` JSON-LD on any of the 73 pages**, and the 64 docs pages — the bulk of the indexable surface — carried **zero** structured data of any kind.
- **`http://useupup.com/` serves the full page: 200, byte-identical to https, no redirect, no HSTS.** Plaintext is a second live origin for the whole site.
- Both sitemap URLs still registered in Search Console are **dead**: `/sitemap-landing.xml` 404s outright, `/documentation/sitemap.xml` takes two hops into a 404. GSC has been reporting "couldn't fetch" for both.
- **`llms.txt` is linked from nowhere** — 0 `<a href>` to it in any page's HTML. Same for the 65 `/docs-md/` markdown twins: reachable only from a client-side `fetch` in the Copy button, and served with no canonical back-link, so if discovered they are duplicates of every docs page under a second URL.
- **robots.txt has no AI-agent group** — a single `*` rule, no GPTBot/ClaudeBot/PerplexityBot/Google-Extended anywhere in the repo.
- Sitemap `lastmod` was a single build timestamp on all 73 URLs — a fake "everything changed" signal Google's documentation says it learns to ignore.
- `/mobile-demo/` is a 200 HTML page with the homepage's title, no canonical and no robots directive; `Disallow` in robots.txt blocks crawling, not indexing.

The AI-crawler probe is the one thing that came back clean: **57/57 pass at Cloudflare** — nothing is being blocked at the edge, so the only reason agents don't cite us is that we never gave them anything to cite.

## Changes (all `apps/landing` unless noted)

**Entity graph.** New `src/components/StructuredData/EntityStructuredData.tsx` emits an `Organization` (`@id` `/#organization`, `alternateName` for the three spellings the brand is searched under, `logo`, `parentOrganization: Devino`) plus a `WebSite` (`@id` `/#website`, `publisher` → the org). It is mounted from the **root layout**, so it reaches every page including all 64 docs pages. `sameAs` carries only URLs verified live on 2026-09-12: the GitHub repo, the npm package (`@useupup/react`, latest 3.3.3 on the registry), and the README's Discord invite (301s to `discord.com/invite/…`; the invite API returns a live, non-expiring guild). The existing `SoftwareApplication` gains `@id` `/#software` and `author`/`publisher` pointing at the org by `@id`. No `AggregateRating`, no `Review` — pinned by a negative assertion. FAQPage is unchanged.

**Docs structured data + markdown-twin discoverability.** `docs/[[...slug]]/page.tsx` now declares `alternates.types['text/markdown']`, rendering `<link rel="alternate" type="text/markdown">`. New `DocsStructuredData` emits `BreadcrumbList` (from the same `findTrail(tree, url)` the visual breadcrumb uses, so they cannot disagree) and `TechArticle` (`isPartOf` the WebSite, `publisher` the Organization). **No dates** — content/docs has none and inventing one is worse than omitting it. A crawlable `<a href="/docs-md/<slug>/">View as Markdown</a>` sits next to the Copy-page button, and `docs-md/[[...slug]]/route.ts` answers with `Link: <canonical html url>; rel="canonical"` so the twin is an alternate representation, not a duplicate.

**llms.txt discoverability.** Real `<a href="/llms.txt">` links in the footer (every page) and on the docs hub.

**robots.txt AI allow-list.** New `src/lib/seo/ai-crawlers.ts` exports the exact 18 agent names; `robots.ts` adds a second rules entry for them alongside `*`, both sharing ONE `disallow` constant so a named agent can never get a laxer list than the wildcard (that would be a side door into `/api/`).

**Scheme, HSTS, stale paths (`next.config.mjs`).** Production now sends `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`; non-prod keeps only `X-Robots-Tag` and gets no HSTS. An http→https redirect keyed **only** on Cloudflare's `cf-visitor` header sits first in `redirects()` — never `x-forwarded-proto`, which Traefik rewrites and which would loop. It is two rules, not one: Next strips the trailing slash before matching a source and does not re-append it to an *absolute* destination, so a single `${SITE_BASE}/:path*` would send `/react/` to `…/react` and cost a second 308. The first rule matches extensionless paths and restores the slash; file paths and the bare root fall through to the second, which must not gain one. Added single-hop redirects for the two stale GSC sitemaps, and host-scoped `/robots.txt` + `/sitemap.xml` rules for the docs alias (they previously chained into a 404).

**Sitemap.** `lastModified` removed from all 73 entries. Priorities, `changeFrequency` and the fumadocs enumeration are untouched.

**`/mobile-demo/` noindex.** New `mobile-demo/layout.tsx` carries `robots: { index: false, follow: false }` (the page is `'use client'` and cannot export metadata). The robots.txt `Disallow` stays — they cover different things.

## Verification

Production build (`turbo run build --filter=@useupup/landing --force`, 4/4 tasks) served by `next start -p 4466`:

```
# http -> https, triggered ONLY by cf-visitor, slash preserved for pages and
# correctly absent for file paths
/react/               => 308 https://useupup.com/react/
/docs/getting-started/=> 308 https://useupup.com/docs/getting-started/
/robots.txt           => 308 https://useupup.com/robots.txt
/                     => 308 https://useupup.com/
# the same requests WITHOUT the header are served normally
/react/    => 200
/robots.txt=> 200
/          => 200

# stale Search Console sitemaps, one hop each
/sitemap-landing.xml        => 308 http://localhost:4466/sitemap.xml
/documentation/sitemap.xml  => 308 http://localhost:4466/sitemap.xml

# docs alias host (Host: docs.useupup.com) — previously 308 -> 308 -> 404
/robots.txt  => 308 https://useupup.com/robots.txt
/sitemap.xml => 308 https://useupup.com/sitemap.xml

# HSTS
GET / -> 200, strict-transport-security: max-age=63072000; includeSubDomains; preload

# markdown twin
GET /docs-md/getting-started/ -> 200
  content-type: text/markdown; charset=utf-8
  link: <https://useupup.com/docs/getting-started/>; rel="canonical"

# sitemap
loc count = 73, lastmod count = 0, mobile-demo = 0, docs-md = 0

# /mobile-demo/
<meta name="robots" content="noindex, nofollow"/>

# robots.txt body
User-Agent: *
Allow: /
Disallow: /api/
Disallow: /mobile-demo/

User-Agent: GPTBot
User-Agent: OAI-SearchBot
User-Agent: ChatGPT-User
User-Agent: ClaudeBot
User-Agent: Claude-User
User-Agent: Claude-SearchBot
User-Agent: anthropic-ai
User-Agent: PerplexityBot
User-Agent: Perplexity-User
User-Agent: Google-Extended
User-Agent: Googlebot
User-Agent: Bingbot
User-Agent: Applebot
User-Agent: Applebot-Extended
User-Agent: CCBot
User-Agent: Amazonbot
User-Agent: Bytespider
User-Agent: meta-externalagent
Allow: /
Disallow: /api/
Disallow: /mobile-demo/

Sitemap: https://useupup.com/sitemap.xml

# /docs/getting-started/ HTML
<link rel="canonical" href="https://useupup.com/docs/getting-started/"/>
<link rel="alternate" type="text/markdown" href="https://useupup.com/docs-md/getting-started/"/>
<a href="/docs-md/getting-started/" data-testid="docs-view-markdown" …>
JSON-LD block 1 @graph: Organization, WebSite
JSON-LD block 2 @graph: BreadcrumbList, TechArticle
  BreadcrumbList: [1 Docs -> https://useupup.com/docs/, 2 Getting Started -> https://useupup.com/docs/getting-started/]
  TechArticle: isPartOf {@id: …/#website}, publisher {@id: …/#organization}, no dates

# homepage
JSON-LD: [Organization, WebSite], SoftwareApplication, FAQPage
SoftwareApplication @id=https://useupup.com/#software
  author=https://useupup.com/#organization  publisher=https://useupup.com/#organization
AggregateRating occurrences: 0   "Review" occurrences: 0
footer: <a href="/llms.txt" …>
```

Gates, all from `rtk proxy` with the raw exit code:

| Gate | Result |
|---|---|
| `turbo run lint typecheck test --filter=@useupup/landing --force` | **PASS** — 15/15 tasks, 81 tests in 9 files |
| `pnpm run test:quality` | **PASS** — 400 test files + 5 workflows clean, 0 exceptions |
| `pnpm run vocab:check` | **PASS** — 1415 tracked files clean |
| `prettier --check` on all 15 touched files | **PASS** |
| `turbo run build --filter=@useupup/landing --force` | **PASS** — 4/4 |
| Playwright `--project docs` | **PASS** — 21/21 (15 pre-existing + 6 new) |

## What CI covers

New vitest `apps/landing/src/__tests__/seo-surfaces.test.ts` (14 tests, runs in `main.yml` › Test):

- sitemap has exactly 1 + 6 + 2 + 64 entries, every URL is `https://useupup.com/…` with a trailing slash, none contains `/mobile-demo`, `/api/`, `/docs-md` or `/llms`, and **no entry carries `lastModified`** — the fake-freshness signal cannot come back silently.
- prod robots: the `*` rule allows `/` and disallows `/api/` + `/mobile-demo/`; a second rule lists **exactly** `AI_CRAWLER_USER_AGENTS` with the same disallow set; the sitemap URL is the production one. Non-prod (`NEXT_PUBLIC_BASE_URL` stubbed to the dev host with `vi.stubEnv` + `vi.resetModules`, because `clientEnv` is parsed once at module load) disallows `/`.
- `EntityStructuredData` and `StructuredData` are rendered with `react-dom/server` and every `application/ld+json` block is JSON-parsed: Organization has its `@id`, ≥2 https `sameAs` URLs, `alternateName`, and Devino as `parentOrganization`; WebSite's `publisher` and SoftwareApplication's `author`/`publisher` both resolve to the org `@id`; `AggregateRating` and `Review` appear nowhere.
- The 18-name crawler list is pinned literally — spelling is load-bearing, since robots.txt matches on these exact tokens.

New Playwright cases in `apps/e2e-test/landing/docs.spec.ts` (the `Docs-E2E` job, which runs on every landing PR): canonical + `rel=alternate` markdown link on `/docs/getting-started/` and the twin's 200 / `text/markdown` / `rel="canonical"` `Link` header; the `cf-visitor` 308 to `https://useupup.com/react/` **and** the plain request still 200; `/sitemap-landing.xml` → 308; the HSTS header on `/`; `User-Agent: GPTBot` in the robots body; the footer `/llms.txt` link. The dev server the project boots leaves `NEXT_PUBLIC_BASE_URL` unset, so `next.config.mjs` computes the production `SITE_BASE` and takes the production branch of `headers()`/`redirects()` — confirmed live, the HSTS assertion holds under `next dev`.

The existing `docs-llms.test.ts`, `docs-source.test.ts` (64 pages), `site-url.test.ts` and the `docs.spec.ts` redirect cases are unchanged and green.

## Owner-only items (not in this PR)

1. **Cloudflare zone, useupup.com**: SSL/TLS → Edge Certificates → **Always Use HTTPS = ON**, then **HSTS = ON**. The `cf-visitor` rule here is the in-repo braces; the zone toggle is the belt and stops the plaintext request before it reaches the container.
2. **Search Console**: delete the two stale sitemap submissions (`/sitemap-landing.xml`, `/documentation/sitemap.xml`) and keep only `https://useupup.com/sitemap.xml`. They now 308 instead of 404, but the submissions themselves should go.
3. **`app.useupup.com`**: the DNS record resolves through Cloudflare and lands on the **BioFlow** container (404 `text/plain` with BioFlow's CSP and HSTS). Delete the `app` record, or add a Traefik router that 308s it to `https://useupup.com/`.
4. **HSTS preload**: submit at hstspreload.org — but only after this header has been live on production for a while. `preload` in the value is a prerequisite for submitting, not the submission.
